### PR TITLE
Fixed array inside array on slide end-points

### DIFF
--- a/public/api-spec-v1.yaml
+++ b/public/api-spec-v1.yaml
@@ -3228,9 +3228,7 @@ components:
           items:
             type: string
         onPlaylists:
-          type: array
-          items:
-            type: string
+          $ref: '#/components/schemas/Collection'
         duration:
           type: integer
           nullable: true
@@ -3302,9 +3300,7 @@ components:
           items:
             type: string
         onPlaylists:
-          type: array
-          items:
-            type: string
+          $ref: '#/components/schemas/Collection.jsonld'
         duration:
           type: integer
           nullable: true

--- a/src/DataTransformer/SlideOutputDataTransformer.php
+++ b/src/DataTransformer/SlideOutputDataTransformer.php
@@ -35,11 +35,11 @@ class SlideOutputDataTransformer implements DataTransformerInterface
             'options' => $slide->getTemplateOptions(),
         ];
 
-        $output->onPlaylists[] = $slide->getPlaylistSlides()->map(function (PlaylistSlide $playlistSlide) {
+        $output->onPlaylists = $slide->getPlaylistSlides()->map(function (PlaylistSlide $playlistSlide) {
             return $this->iriConverter->getIriFromItem($playlistSlide->getPlaylist());
         });
 
-        $output->media[] = $slide->getMedia()->map(function (Media $media) {
+        $output->media = $slide->getMedia()->map(function (Media $media) {
             return $this->iriConverter->getIriFromItem($media);
         });
 

--- a/src/Dto/Slide.php
+++ b/src/Dto/Slide.php
@@ -19,7 +19,7 @@ class Slide
         'options' => [],
     ];
 
-    public array $onPlaylists = [];
+    public Collection $onPlaylists;
     public ?int $duration = null;
     public array $published = [
         'from' => 0,
@@ -31,6 +31,7 @@ class Slide
 
     public function __construct()
     {
+        $this->onPlaylists = new ArrayCollection();
         $this->media = new ArrayCollection();
     }
 }


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/AR-708

#### Description

The properties `onPlaylists` and `media` was arrays inside arrays, they should not have this extra layer of arrays. This PR fixes that

#### Screenshot of the result

![Screenshot 2021-10-27 at 20 20 41](https://user-images.githubusercontent.com/111397/139124243-eb541492-00f7-460a-aef8-3285266cb67f.png)

![Screenshot 2021-10-27 at 20 20 45](https://user-images.githubusercontent.com/111397/139124254-e29b1a7a-f4ac-4921-863e-6218bdd0e812.png)

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

Note: the ticket linked is an random AR ticket... just needed one for this 5 min fix.
