### PR TITLE
Add microseconds to datetime format to support format given by EcmaSc…

### DIFF
--- a/.env
+++ b/.env
@@ -35,5 +35,5 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
 
 ###> App ###
-APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s\Z'
+APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s:v\Z'
 ###< App ###

--- a/.env
+++ b/.env
@@ -35,5 +35,5 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
 
 ###> App ###
-APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s:v\Z'
+APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s.v\Z'
 ###< App ###

--- a/config/api_platform/playlist.yaml
+++ b/config/api_platform/playlist.yaml
@@ -5,7 +5,7 @@ resources:
       input: App\Dto\PlaylistInput
       output: App\Dto\Playlist
       normalization_context:
-        datetime_format: 'Y-m-d\TH:i:s\Z'
+        datetime_format: 'Y-m-d\TH:i:s:v\Z'
     itemOperations:
       get:
         openapi_context:

--- a/config/api_platform/playlist.yaml
+++ b/config/api_platform/playlist.yaml
@@ -5,7 +5,7 @@ resources:
       input: App\Dto\PlaylistInput
       output: App\Dto\Playlist
       normalization_context:
-        datetime_format: 'Y-m-d\TH:i:s:v\Z'
+        datetime_format: 'Y-m-d\TH:i:s.v\Z'
     itemOperations:
       get:
         openapi_context:

--- a/config/api_platform/slide.yaml
+++ b/config/api_platform/slide.yaml
@@ -5,7 +5,7 @@ resources:
       input: App\Dto\SlideInput
       output: App\Dto\Slide
       normalization_context:
-        datetime_format: 'Y-m-d\TH:i:s\Z'
+        datetime_format: 'Y-m-d\TH:i:s:v\Z'
     itemOperations:
       get:
         openapi_context:

--- a/config/api_platform/slide.yaml
+++ b/config/api_platform/slide.yaml
@@ -5,7 +5,7 @@ resources:
       input: App\Dto\SlideInput
       output: App\Dto\Slide
       normalization_context:
-        datetime_format: 'Y-m-d\TH:i:s:v\Z'
+        datetime_format: 'Y-m-d\TH:i:s.v\Z'
     itemOperations:
       get:
         openapi_context:

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -22,7 +22,7 @@ services:
       - APP_SECRET=MySuperSecret
       - APP_CORS_ALLOW_ORIGIN='^https?://localhost(:[0-9]+)?$'
       - APP_DATABASE_URL=mysql://db:db@mariadb:3306/db?serverVersion=mariadb-10.4.0
-      - APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s:v\Z'
+      - APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s.v\Z'
 
   nginx:
     image: itkdev/os2display-api-service-nginx:alpha

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -22,7 +22,7 @@ services:
       - APP_SECRET=MySuperSecret
       - APP_CORS_ALLOW_ORIGIN='^https?://localhost(:[0-9]+)?$'
       - APP_DATABASE_URL=mysql://db:db@mariadb:3306/db?serverVersion=mariadb-10.4.0
-      - APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s\Z'
+      - APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s:v\Z'
 
   nginx:
     image: itkdev/os2display-api-service-nginx:alpha

--- a/src/Utils/ValidationUtils.php
+++ b/src/Utils/ValidationUtils.php
@@ -30,7 +30,9 @@ final class ValidationUtils
     {
         $errors = $this->validator->validate($date, new Assert\DateTime($this->bindDefaultDateFormat));
         if (0 !== count($errors)) {
-            throw new InvalidArgumentException('Date format not valid, valid format is '.$this->bindDefaultDateFormat);
+            $epoc = new \DateTime();
+            $example = $epoc->setTimestamp(0)->format($this->bindDefaultDateFormat);
+            throw new InvalidArgumentException(sprintf('%s is not a valid date format, valid format is simplified extended ISO format, e.g %s', $date, $example));
         }
 
         return new \DateTime($date);

--- a/src/Utils/ValidationUtils.php
+++ b/src/Utils/ValidationUtils.php
@@ -30,8 +30,8 @@ final class ValidationUtils
     {
         $errors = $this->validator->validate($date, new Assert\DateTime($this->bindDefaultDateFormat));
         if (0 !== count($errors)) {
-            $epoc = new \DateTime();
-            $example = $epoc->setTimestamp(0)->format($this->bindDefaultDateFormat);
+            $epoc = \DateTime::createFromFormat('Y-m-d\TH:i:s.v\Z', '1970-01-01T01:02:03.000Z');
+            $example = $epoc->format($this->bindDefaultDateFormat);
             throw new InvalidArgumentException(sprintf('%s is not a valid date format, valid format is simplified extended ISO format, e.g %s', $date, $example));
         }
 

--- a/src/Utils/ValidationUtils.php
+++ b/src/Utils/ValidationUtils.php
@@ -30,7 +30,7 @@ final class ValidationUtils
     {
         $errors = $this->validator->validate($date, new Assert\DateTime($this->bindDefaultDateFormat));
         if (0 !== count($errors)) {
-            throw new InvalidArgumentException('Date format not valid');
+            throw new InvalidArgumentException('Date format not valid, valid format is '.$this->bindDefaultDateFormat);
         }
 
         return new \DateTime($date);

--- a/tests/Api/PlaylistsTest.php
+++ b/tests/Api/PlaylistsTest.php
@@ -73,8 +73,8 @@ class PlaylistsTest extends ApiTestCase
                 'modifiedBy' => 'Test Tester',
                 'createdBy' => 'Hans Tester',
                 'published' => [
-                    'from' => '2021-09-21T17:00:01Z',
-                    'to' => '2021-07-22T17:00:01Z',
+                    'from' => '2021-09-21T17:00:01.000Z',
+                    'to' => '2021-07-22T17:00:01.000Z',
                 ],
             ],
             'headers' => [
@@ -104,8 +104,8 @@ class PlaylistsTest extends ApiTestCase
             'modifiedBy' => 'Test Tester',
             'createdBy' => 'Hans Tester',
             'published' => [
-                'from' => '2021-09-21T17:00:01Z',
-                'to' => '2021-07-22T17:00:01Z',
+                'from' => '2021-09-21T17:00:01.000Z',
+                'to' => '2021-07-22T17:00:01.000Z',
             ],
         ]);
         $this->assertMatchesRegularExpression('@^/v\d/\w+/([A-Za-z0-9]{26})$@', $response->toArray()['@id']);
@@ -118,8 +118,8 @@ class PlaylistsTest extends ApiTestCase
                 'modifiedBy' => 'Test Tester',
                 'createdBy' => 'Hans Tester',
                 'published' => [
-                    'from' => '2021-09-21T17:00:01Z',
-                    'to' => '2021-07-22T17:00:01Z',
+                    'from' => '2021-09-21T17:00:01.000Z',
+                    'to' => '2021-07-22T17:00:01.000Z',
                 ],
             ],
             'headers' => [
@@ -149,8 +149,8 @@ class PlaylistsTest extends ApiTestCase
             'modifiedBy' => 'Test Tester',
             'createdBy' => 'Hans Tester',
             'published' => [
-                'from' => '2021-09-21T17:00:01Z',
-                'to' => '2021-07-22T17:00:01Z',
+                'from' => '2021-09-21T17:00:01.000Z',
+                'to' => '2021-07-22T17:00:01.000Z',
             ],
         ]);
         $this->assertMatchesRegularExpression('@^/v\d/\w+/([A-Za-z0-9]{26})$@', $response->toArray()['@id']);
@@ -186,8 +186,8 @@ class PlaylistsTest extends ApiTestCase
         static::createClient()->request('POST', '/v1/playlists', [
             'json' => [
                 'published' => [
-                    'from' => '2021-09-201T17:00:01Z',
-                    'to' => '2021-42-22T17:00:01Z',
+                    'from' => '2021-09-201T17:00:01.000Z',
+                    'to' => '2021-42-22T17:00:01.000Z',
                 ],
             ],
             'headers' => [
@@ -202,7 +202,7 @@ class PlaylistsTest extends ApiTestCase
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
             'hydra:title' => 'An error occurred',
-            'hydra:description' => 'Date format not valid',
+            'hydra:description' => '2021-09-201T17:00:01.000Z is not a valid date format, valid format is simplified extended ISO format, e.g 1970-01-01T00:00:00.000Z',
         ]);
     }
 

--- a/tests/Api/PlaylistsTest.php
+++ b/tests/Api/PlaylistsTest.php
@@ -202,7 +202,7 @@ class PlaylistsTest extends ApiTestCase
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
             'hydra:title' => 'An error occurred',
-            'hydra:description' => '2021-09-201T17:00:01.000Z is not a valid date format, valid format is simplified extended ISO format, e.g 1970-01-01T00:00:00.000Z',
+            'hydra:description' => '2021-09-201T17:00:01.000Z is not a valid date format, valid format is simplified extended ISO format, e.g 1970-01-01T01:02:03.000Z',
         ]);
     }
 

--- a/tests/Api/SlidesTest.php
+++ b/tests/Api/SlidesTest.php
@@ -90,8 +90,8 @@ class SlidesTest extends ApiTestCase
                 'theme' => $themeIri,
                 'duration' => 60000,
                 'published' => [
-                    'from' => '2021-09-21T17:00:01Z',
-                    'to' => '2021-07-22T17:00:01Z',
+                    'from' => '2021-09-21T17:00:01.000Z',
+                    'to' => '2021-07-22T17:00:01.000Z',
                 ],
                 'content' => [
                     'text' => 'Test text',
@@ -134,8 +134,8 @@ class SlidesTest extends ApiTestCase
             'theme' => $themeIri,
             'duration' => 60000,
             'published' => [
-                'from' => '2021-09-21T17:00:01Z',
-                'to' => '2021-07-22T17:00:01Z',
+                'from' => '2021-09-21T17:00:01.000Z',
+                'to' => '2021-07-22T17:00:01.000Z',
             ],
             'content' => [
                 'text' => 'Test text',
@@ -176,8 +176,8 @@ class SlidesTest extends ApiTestCase
         static::createClient()->request('POST', '/v1/slides', [
             'json' => [
                 'published' => [
-                    'from' => '2021-09-20T17:00:701Z',
-                    'to' => '021-02-22T17:00:01Z',
+                    'from' => '2021-09-20T17:00:01.000Z',
+                    'to' => '21121-02-22T17:00:01.000Z',
                 ],
             ],
             'headers' => [
@@ -192,7 +192,7 @@ class SlidesTest extends ApiTestCase
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
             'hydra:title' => 'An error occurred',
-            'hydra:description' => 'Date format not valid',
+            'hydra:description' => '21121-02-22T17:00:01.000Z is not a valid date format, valid format is simplified extended ISO format, e.g 1970-01-01T00:00:00.000Z',
         ]);
     }
 
@@ -237,8 +237,8 @@ class SlidesTest extends ApiTestCase
                 ],
                 'duration' => 60000,
                 'published' => [
-                    'from' => '2021-09-21T17:00:01Z',
-                    'to' => '2021-07-22T17:00:01Z',
+                    'from' => '2021-09-21T17:00:01.000Z',
+                    'to' => '2021-07-22T17:00:01.000Z',
                 ],
                 'content' => [
                     'text' => 'Test text',

--- a/tests/Api/SlidesTest.php
+++ b/tests/Api/SlidesTest.php
@@ -192,7 +192,7 @@ class SlidesTest extends ApiTestCase
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
             'hydra:title' => 'An error occurred',
-            'hydra:description' => '21121-02-22T17:00:01.000Z is not a valid date format, valid format is simplified extended ISO format, e.g 1970-01-01T00:00:00.000Z',
+            'hydra:description' => '21121-02-22T17:00:01.000Z is not a valid date format, valid format is simplified extended ISO format, e.g 1970-01-01T01:02:03.000Z',
         ]);
     }
 

--- a/tests/Utils/ValidationUtilsTest.php
+++ b/tests/Utils/ValidationUtilsTest.php
@@ -23,11 +23,11 @@ class ValidationUtilsTest extends KernelTestCase
         $format = $_ENV['APP_DEFAULT_DATE_FORMAT'];
         $this->assertNotEmpty($format);
 
-        $dateStr = '2021-09-22T17:00:01Z';
+        $dateStr = '2021-09-22T17:00:01.000Z';
         $date = $this->utils->validateDate($dateStr);
 
         $this->assertNotEquals(false, $date->diff(new \DateTime($dateStr)));
-        $this->assertEquals('2021-09-22T17:00:01Z', $date->format($format));
+        $this->assertEquals('2021-09-22T17:00:01.000Z', $date->format($format));
     }
 
     public function testInvalidValidateDate(): void


### PR DESCRIPTION
Add microseconds to datetime format to support format given by EcmaScript Date.prototype.toISOString()

#### Link to ticket

https://jira.itkdev.dk/browse/AR-725

#### Description

EcmaScript has `Date.prototype.toISOString()`([link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)) which gives a string containing microseconds: `2011-10-05T14:48:00.000Z`.

To support this we change the default api datetime format to match the js iso string. This is also supported by OpenAPI whih follows [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6): 
```
partial-time    = time-hour ":" time-minute ":" time-second
                     [time-secfrac]
```

#### Screenshot of the result

<img width="394" alt="Screenshot 2021-11-03 at 13 04 40" src="https://user-images.githubusercontent.com/5631988/140056902-06356a41-569b-4833-8c7a-dea7c2341d90.png">

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
