### PR TITLE
AR-729: Enable Playlist and Slide to be unpublished by allowing null …

### DIFF
--- a/src/DataTransformer/PlaylistInputDataTransformer.php
+++ b/src/DataTransformer/PlaylistInputDataTransformer.php
@@ -37,8 +37,17 @@ final class PlaylistInputDataTransformer implements DataTransformerInterface
         empty($data->createdBy) ?: $playlist->setCreatedBy($data->createdBy);
         empty($data->modifiedBy) ?: $playlist->setModifiedBy($data->modifiedBy);
 
-        null === $data->published['from'] ? $playlist->setPublishedFrom(null) : $playlist->setPublishedFrom($this->utils->validateDate($data->published['from']));
-        null === $data->published['to'] ? $playlist->setPublishedTo(null) : $playlist->setPublishedTo($this->utils->validateDate($data->published['to']));
+        if (null === $data->published['from']) {
+            $playlist->setPublishedFrom(null);
+        } elseif (!empty($data->published['from'])) {
+            $playlist->setPublishedFrom($this->utils->validateDate($data->published['from']));
+        }
+
+        if (null === $data->published['to']) {
+            $playlist->setPublishedTo(null);
+        } elseif (!empty($data->published['to'])) {
+            $playlist->setPublishedTo($this->utils->validateDate($data->published['to']));
+        }
 
         return $playlist;
     }

--- a/src/DataTransformer/PlaylistInputDataTransformer.php
+++ b/src/DataTransformer/PlaylistInputDataTransformer.php
@@ -36,8 +36,9 @@ final class PlaylistInputDataTransformer implements DataTransformerInterface
 
         empty($data->createdBy) ?: $playlist->setCreatedBy($data->createdBy);
         empty($data->modifiedBy) ?: $playlist->setModifiedBy($data->modifiedBy);
-        empty($data->published['from']) ?: $playlist->setPublishedFrom($this->utils->validateDate($data->published['from']));
-        empty($data->published['to']) ?: $playlist->setPublishedTo($this->utils->validateDate($data->published['to']));
+
+        null === $data->published['from'] ? $playlist->setPublishedFrom(null) : $playlist->setPublishedFrom($this->utils->validateDate($data->published['from']));
+        null === $data->published['to'] ? $playlist->setPublishedTo(null) : $playlist->setPublishedTo($this->utils->validateDate($data->published['to']));
 
         return $playlist;
     }

--- a/src/DataTransformer/SlideInputDataTransformer.php
+++ b/src/DataTransformer/SlideInputDataTransformer.php
@@ -42,8 +42,17 @@ final class SlideInputDataTransformer implements DataTransformerInterface
         empty($data->modifiedBy) ?: $slide->setModifiedBy($data->modifiedBy);
         empty($data->duration) ?: $slide->setDuration($data->duration);
 
-        null === $data->published['from'] ? $slide->setPublishedFrom(null) : $slide->setPublishedFrom($this->utils->validateDate($data->published['from']));
-        null === $data->published['to'] ? $slide->setPublishedTo(null) : $slide->setPublishedTo($this->utils->validateDate($data->published['to']));
+        if (null === $data->published['from']) {
+            $slide->setPublishedFrom(null);
+        } elseif (!empty($data->published['from'])) {
+            $slide->setPublishedFrom($this->utils->validateDate($data->published['from']));
+        }
+
+        if (null === $data->published['to']) {
+            $slide->setPublishedTo(null);
+        } elseif (!empty($data->published['to'])) {
+            $slide->setPublishedTo($this->utils->validateDate($data->published['to']));
+        }
 
         empty($data->templateInfo['options']) ?: $slide->setTemplateOptions($data->templateInfo['options']);
         empty($data->content) ?: $slide->setContent($data->content);

--- a/src/DataTransformer/SlideInputDataTransformer.php
+++ b/src/DataTransformer/SlideInputDataTransformer.php
@@ -41,8 +41,10 @@ final class SlideInputDataTransformer implements DataTransformerInterface
         empty($data->createdBy) ?: $slide->setCreatedBy($data->createdBy);
         empty($data->modifiedBy) ?: $slide->setModifiedBy($data->modifiedBy);
         empty($data->duration) ?: $slide->setDuration($data->duration);
-        empty($data->published['from']) ?: $slide->setPublishedFrom($this->utils->validateDate($data->published['from']));
-        empty($data->published['to']) ?: $slide->setPublishedTo($this->utils->validateDate($data->published['to']));
+
+        null === $data->published['from'] ? $slide->setPublishedFrom(null) : $slide->setPublishedFrom($this->utils->validateDate($data->published['from']));
+        null === $data->published['to'] ? $slide->setPublishedTo(null) : $slide->setPublishedTo($this->utils->validateDate($data->published['to']));
+
         empty($data->templateInfo['options']) ?: $slide->setTemplateOptions($data->templateInfo['options']);
         empty($data->content) ?: $slide->setContent($data->content);
 

--- a/tests/Api/PlaylistsTest.php
+++ b/tests/Api/PlaylistsTest.php
@@ -159,6 +159,38 @@ class PlaylistsTest extends ApiTestCase
         // $this->assertMatchesResourceItemJsonSchema(Playlist::class);
     }
 
+    public function testCreateUnpublishedPlaylist(): void
+    {
+        $response = static::createClient()->request('POST', '/v1/playlists', [
+            'json' => [
+                'title' => 'Test playlist',
+                'description' => 'This is a test playlist',
+                'schedule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                'modifiedBy' => 'Test Tester',
+                'createdBy' => 'Hans Tester',
+                'published' => [
+                    'from' => null,
+                    'to' => null,
+                ],
+            ],
+            'headers' => [
+                'Content-Type' => 'application/ld+json',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertJsonContains([
+            '@type' => 'Playlist',
+            'title' => 'Test playlist',
+            'description' => 'This is a test playlist',
+            'published' => [
+                'from' => null,
+                'to' => null,
+            ],
+        ]);
+    }
+
     public function testCreateInvalidPlaylist(): void
     {
         static::createClient()->request('POST', '/v1/playlists', [
@@ -225,6 +257,36 @@ class PlaylistsTest extends ApiTestCase
             '@type' => 'Playlist',
             '@id' => $iri,
             'title' => 'Updated title',
+        ]);
+    }
+
+    public function testUpdatePlaylistToUnpublished(): void
+    {
+        $client = static::createClient();
+        $iri = $this->findIriBy(Playlist::class, []);
+
+        $client->request('PUT', $iri, [
+            'json' => [
+                'title' => 'Updated title',
+                'published' => [
+                    'from' => null,
+                    'to' => null,
+                ],
+            ],
+            'headers' => [
+                'Content-Type' => 'application/ld+json',
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            '@type' => 'Playlist',
+            '@id' => $iri,
+            'title' => 'Updated title',
+            'published' => [
+                'from' => null,
+                'to' => null,
+            ],
         ]);
     }
 

--- a/tests/Api/ScreenGroupsTest.php
+++ b/tests/Api/ScreenGroupsTest.php
@@ -172,7 +172,7 @@ class ScreenGroupsTest extends ApiTestCase
             '@id' => '/v1/screen-groups',
             '@type' => 'hydra:Collection',
             'hydra:view' => [
-                '@id' => '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2&page=1',
+                '@id' => '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2',
                 '@type' => 'hydra:PartialCollectionView',
             ],
         ]);

--- a/tests/Api/ScreenGroupsTest.php
+++ b/tests/Api/ScreenGroupsTest.php
@@ -160,8 +160,7 @@ class ScreenGroupsTest extends ApiTestCase
     {
         $client = static::createClient();
 
-        $iri = $this->findIriBy(Screen::class, []);
-        $ulid = $this->iriHelperUtils->getUlidFromIRI($iri);
+        $ulid = '01FKZZ3HHK2ESG3PMV2KXTX5QY';
 
         $client->request('GET', '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2&page=1', ['headers' => ['Content-Type' => 'application/ld+json']]);
 
@@ -172,6 +171,7 @@ class ScreenGroupsTest extends ApiTestCase
             '@id' => '/v1/screen-groups',
             '@type' => 'hydra:Collection',
             'hydra:view' => [
+                '@id' => '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2',
                 '@type' => 'hydra:PartialCollectionView',
             ],
         ]);

--- a/tests/Api/ScreenGroupsTest.php
+++ b/tests/Api/ScreenGroupsTest.php
@@ -163,7 +163,7 @@ class ScreenGroupsTest extends ApiTestCase
         $iri = $this->findIriBy(Screen::class, []);
         $ulid = $this->iriHelperUtils->getUlidFromIRI($iri);
 
-        $client->request('GET', '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2', ['headers' => ['Content-Type' => 'application/ld+json']]);
+        $client->request('GET', '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2&page=1', ['headers' => ['Content-Type' => 'application/ld+json']]);
 
         $this->assertResponseIsSuccessful();
         $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
@@ -172,7 +172,7 @@ class ScreenGroupsTest extends ApiTestCase
             '@id' => '/v1/screen-groups',
             '@type' => 'hydra:Collection',
             'hydra:view' => [
-                '@id' => '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2',
+                '@id' => '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2&page=1',
                 '@type' => 'hydra:PartialCollectionView',
             ],
         ]);

--- a/tests/Api/ScreenGroupsTest.php
+++ b/tests/Api/ScreenGroupsTest.php
@@ -172,7 +172,6 @@ class ScreenGroupsTest extends ApiTestCase
             '@id' => '/v1/screen-groups',
             '@type' => 'hydra:Collection',
             'hydra:view' => [
-                '@id' => '/v1/screens/'.$ulid.'/screen-groups?itemsPerPage=2',
                 '@type' => 'hydra:PartialCollectionView',
             ],
         ]);


### PR DESCRIPTION
…on published dates

#### Link to ticket

https://jira.itkdev.dk/browse/AR-729

#### Description

Allow `null` on published dates to allow creating and updating `Slide` and `Play`to be unpublished.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
