### PR TITLE
AR-692: Change playlist.schedule to an array of Schedule entities

### DIFF
--- a/fixtures/playlist.yaml
+++ b/fixtures/playlist.yaml
@@ -5,6 +5,8 @@ App\Entity\Playlist:
     createdAt: <ulidDate(@self->id)>
     title: <sentence(4)>
     description: <text()>
-    schedule: <rrule()>
+    schedules:
+      - '@schedule_1'
+      - '@schedule_2'
     publishedFrom: <dateTimeBetween('-1 year', '+2 month')>
     publishedTo: <dateTimeBetween($publishedFrom, '+2 month')>

--- a/fixtures/schedule.yaml
+++ b/fixtures/schedule.yaml
@@ -1,0 +1,6 @@
+---
+App\Entity\Schedule:
+  schedule_{1..2}:
+    id: <ulid()>
+    rrule: <rrule()>
+    duration: <numberBetween(1000, 3600)>

--- a/migrations/Version20211126082844.php
+++ b/migrations/Version20211126082844.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211126082844 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE schedule (id BINARY(16) NOT NULL COMMENT \'(DC2Type:ulid)\', playlist_id BINARY(16) NOT NULL COMMENT \'(DC2Type:ulid)\', rrule VARCHAR(255) NOT NULL COMMENT \'(DC2Type:rrule)\', duration INT NOT NULL, INDEX IDX_5A3811FB6BBD148 (playlist_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE schedule ADD CONSTRAINT FK_5A3811FB6BBD148 FOREIGN KEY (playlist_id) REFERENCES playlist (id)');
+        $this->addSql('ALTER TABLE playlist DROP schedule');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE schedule');
+        $this->addSql('ALTER TABLE playlist ADD schedule VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'(DC2Type:rrule)\'');
+    }
+}

--- a/public/api-spec-v1.yaml
+++ b/public/api-spec-v1.yaml
@@ -2869,8 +2869,10 @@ components:
           type: string
         description:
           type: string
-        schedule:
-          type: string
+        schedules:
+          type: array
+          items:
+            type: string
         created:
           type: string
           format: date-time
@@ -2924,8 +2926,10 @@ components:
           type: string
         description:
           type: string
-        schedule:
-          type: string
+        schedules:
+          type: array
+          items:
+            type: string
         created:
           type: string
           format: date-time
@@ -2956,8 +2960,10 @@ components:
           type: string
         description:
           type: string
-        schedule:
-          type: string
+        schedules:
+          type: array
+          items:
+            type: string
         modifiedBy:
           type: string
         createdBy:
@@ -3003,8 +3009,10 @@ components:
           type: string
         description:
           type: string
-        schedule:
-          type: string
+        schedules:
+          type: array
+          items:
+            type: string
         modifiedBy:
           type: string
         createdBy:

--- a/src/DataTransformer/PlaylistInputDataTransformer.php
+++ b/src/DataTransformer/PlaylistInputDataTransformer.php
@@ -5,6 +5,7 @@ namespace App\DataTransformer;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use App\Dto\PlaylistInput;
 use App\Entity\Playlist;
+use App\Entity\Schedule;
 use App\Utils\ValidationUtils;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
@@ -31,8 +32,16 @@ final class PlaylistInputDataTransformer implements DataTransformerInterface
         empty($data->title) ?: $playlist->setTitle($data->title);
         empty($data->description) ?: $playlist->setDescription($data->description);
 
-        empty($data->schedule) ?: $data->schedule = $this->transformRRuleNewline($data->schedule);
-        empty($data->schedule) ?: $playlist->setSchedule($this->utils->validateRRule($data->schedule));
+        if (!empty($data->schedules)) {
+            foreach ($data->schedules as $scheduleData) {
+                $schedule = new Schedule();
+                $rrule = $this->transformRRuleNewline($scheduleData['rrule']);
+                $schedule->setRrule($this->utils->validateRRule($rrule));
+                $schedule->setDuration($scheduleData['duration']);
+                $schedule->setPlaylist($playlist);
+                $playlist->addSchedule($schedule);
+            }
+        }
 
         empty($data->createdBy) ?: $playlist->setCreatedBy($data->createdBy);
         empty($data->modifiedBy) ?: $playlist->setModifiedBy($data->modifiedBy);

--- a/src/DataTransformer/PlaylistInputDataTransformer.php
+++ b/src/DataTransformer/PlaylistInputDataTransformer.php
@@ -32,6 +32,12 @@ final class PlaylistInputDataTransformer implements DataTransformerInterface
         empty($data->title) ?: $playlist->setTitle($data->title);
         empty($data->description) ?: $playlist->setDescription($data->description);
 
+        // Remove all schedules.
+        foreach ($playlist->getSchedules() as $schedule) {
+            $playlist->removeSchedule($schedule);
+        }
+
+        // Add schedules.
         if (!empty($data->schedules)) {
             foreach ($data->schedules as $scheduleData) {
                 $schedule = new Schedule();

--- a/src/DataTransformer/PlaylistInputDataTransformer.php
+++ b/src/DataTransformer/PlaylistInputDataTransformer.php
@@ -32,13 +32,13 @@ final class PlaylistInputDataTransformer implements DataTransformerInterface
         empty($data->title) ?: $playlist->setTitle($data->title);
         empty($data->description) ?: $playlist->setDescription($data->description);
 
-        // Remove all schedules.
-        foreach ($playlist->getSchedules() as $schedule) {
-            $playlist->removeSchedule($schedule);
-        }
-
-        // Add schedules.
         if (!empty($data->schedules)) {
+            // Remove all schedules.
+            foreach ($playlist->getSchedules() as $schedule) {
+                $playlist->removeSchedule($schedule);
+            }
+
+            // Add schedules.
             foreach ($data->schedules as $scheduleData) {
                 $schedule = new Schedule();
                 $rrule = $this->utils->validateRRule($this->transformRRuleNewline($scheduleData['rrule']));

--- a/src/DataTransformer/PlaylistInputDataTransformer.php
+++ b/src/DataTransformer/PlaylistInputDataTransformer.php
@@ -35,8 +35,8 @@ final class PlaylistInputDataTransformer implements DataTransformerInterface
         if (!empty($data->schedules)) {
             foreach ($data->schedules as $scheduleData) {
                 $schedule = new Schedule();
-                $rrule = $this->transformRRuleNewline($scheduleData['rrule']);
-                $schedule->setRrule($this->utils->validateRRule($rrule));
+                $rrule = $this->utils->validateRRule($this->transformRRuleNewline($scheduleData['rrule']));
+                $schedule->setRrule($rrule);
                 $schedule->setDuration($scheduleData['duration']);
                 $schedule->setPlaylist($playlist);
                 $playlist->addSchedule($schedule);

--- a/src/DataTransformer/PlaylistOutputDataTransformer.php
+++ b/src/DataTransformer/PlaylistOutputDataTransformer.php
@@ -24,10 +24,14 @@ class PlaylistOutputDataTransformer implements DataTransformerInterface
         $output->title = $playlist->getTitle();
         $output->description = $playlist->getDescription();
 
-        $schedule = $playlist->getSchedule();
-        if (null !== $schedule) {
-            $output->schedule = $this->transformRRuleNewline($schedule->rfcString(true));
+        $schedulesOutput = [];
+        foreach ($playlist->getSchedules() as $schedule) {
+            $schedulesOutput[] = [
+                'rrule' => $this->transformRRuleNewline($schedule->getRrule()->rfcString(true)),
+                'duration' => $schedule->getDuration(),
+            ];
         }
+        $output->schedules = $schedulesOutput;
 
         $output->created = $playlist->getCreatedAt();
         $output->modified = $playlist->getUpdatedAt();

--- a/src/DataTransformer/PlaylistOutputDataTransformer.php
+++ b/src/DataTransformer/PlaylistOutputDataTransformer.php
@@ -27,6 +27,7 @@ class PlaylistOutputDataTransformer implements DataTransformerInterface
         $schedulesOutput = [];
         foreach ($playlist->getSchedules() as $schedule) {
             $schedulesOutput[] = [
+                'id' => $schedule->getId(),
                 'rrule' => $this->transformRRuleNewline($schedule->getRrule()->rfcString(true)),
                 'duration' => $schedule->getDuration(),
             ];

--- a/src/Dto/Playlist.php
+++ b/src/Dto/Playlist.php
@@ -6,7 +6,7 @@ class Playlist
 {
     public string $title = '';
     public string $description = '';
-    public string $schedule = '';
+    public array $schedules = [];
     public \DateTimeInterface $created;
     public \DateTimeInterface $modified;
     public string $modifiedBy = '';

--- a/src/Dto/PlaylistInput.php
+++ b/src/Dto/PlaylistInput.php
@@ -6,12 +6,7 @@ class PlaylistInput
 {
     public string $title = '';
     public string $description = '';
-    public array $schedules = [
-        [
-            'rrule' => '',
-            'duration' => 0,
-        ]
-    ];
+    public array $schedules = [];
     public string $modifiedBy = '';
     public string $createdBy = '';
     public array $published = [

--- a/src/Dto/PlaylistInput.php
+++ b/src/Dto/PlaylistInput.php
@@ -6,7 +6,12 @@ class PlaylistInput
 {
     public string $title = '';
     public string $description = '';
-    public string $schedule = '';
+    public array $schedules = [
+        [
+            'rrule' => '',
+            'duration' => 0,
+        ]
+    ];
     public string $modifiedBy = '';
     public string $createdBy = '';
     public array $published = [

--- a/src/Entity/Playlist.php
+++ b/src/Entity/Playlist.php
@@ -7,7 +7,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
-use RRule\RRule;
 
 /**
  * @ORM\Entity(repositoryClass=PlaylistRepository::class)
@@ -34,18 +33,19 @@ class Playlist
      * @ORM\OneToMany(targetEntity=PlaylistSlide::class, mappedBy="playlist", orphanRemoval=true)
      * @ORM\OrderBy({"weight" = "ASC"})
      */
-    private $playlistSlides;
+    private Collection $playlistSlides;
 
     /**
-     * @ORM\Column(type="rrule", nullable=true)
+     * @ORM\OneToMany(targetEntity=Schedule::class, mappedBy="playlist", orphanRemoval=true, cascade={"persist"})
      */
-    private ?RRule $schedule = null;
+    private Collection $schedules;
 
     public function __construct()
     {
         $this->screens = new ArrayCollection();
         $this->playlistScreenRegions = new ArrayCollection();
         $this->playlistSlides = new ArrayCollection();
+        $this->schedules = new ArrayCollection();
     }
 
     /**
@@ -160,14 +160,32 @@ class Playlist
         return $this;
     }
 
-    public function getSchedule(): ?RRule
+    /**
+     * @return Collection|Schedule[]
+     */
+    public function getSchedules(): Collection
     {
-        return $this->schedule;
+        return $this->schedules;
     }
 
-    public function setSchedule(?RRule $schedule): self
+    public function addSchedule(Schedule $schedule): self
     {
-        $this->schedule = $schedule;
+        if (!$this->schedules->contains($schedule)) {
+            $this->schedules[] = $schedule;
+            $schedule->setPlaylist($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSchedule(Schedule $schedule): self
+    {
+        if ($this->schedules->removeElement($schedule)) {
+            // set the owning side to null (unless already changed)
+            if ($schedule->getPlaylist() === $this) {
+                $schedule->setPlaylist(null);
+            }
+        }
 
         return $this;
     }

--- a/src/Entity/Schedule.php
+++ b/src/Entity/Schedule.php
@@ -27,7 +27,7 @@ class Schedule
      * @ORM\ManyToOne(targetEntity=Playlist::class, inversedBy="schedules")
      * @ORM\JoinColumn(nullable=false)
      */
-    private Playlist $playlist;
+    private ?Playlist $playlist;
 
     public function getRrule(): RRule
     {
@@ -58,7 +58,7 @@ class Schedule
         return $this->playlist;
     }
 
-    public function setPlaylist(Playlist $playlist): self
+    public function setPlaylist(?Playlist $playlist): self
     {
         $this->playlist = $playlist;
 

--- a/src/Entity/Schedule.php
+++ b/src/Entity/Schedule.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ScheduleRepository;
+use Doctrine\ORM\Mapping as ORM;
+use RRule\RRule;
+
+/**
+ * @ORM\Entity(repositoryClass=ScheduleRepository::class)
+ */
+class Schedule
+{
+    use EntityIdTrait;
+
+    /**
+     * @ORM\Column(type="rrule")
+     */
+    private ?RRule $rrule;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private ?int $duration;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=Playlist::class, inversedBy="schedules")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private ?Playlist $playlist;
+
+    public function getRrule(): ?RRule
+    {
+        return $this->rrule;
+    }
+
+    public function setRrule(RRule $rrule): self
+    {
+        $this->rrule = $rrule;
+
+        return $this;
+    }
+
+    public function getDuration(): ?int
+    {
+        return $this->duration;
+    }
+
+    public function setDuration(int $duration): self
+    {
+        $this->duration = $duration;
+
+        return $this;
+    }
+
+    public function getPlaylist(): ?Playlist
+    {
+        return $this->playlist;
+    }
+
+    public function setPlaylist(?Playlist $playlist): self
+    {
+        $this->playlist = $playlist;
+
+        return $this;
+    }
+}

--- a/src/Entity/Schedule.php
+++ b/src/Entity/Schedule.php
@@ -16,20 +16,20 @@ class Schedule
     /**
      * @ORM\Column(type="rrule")
      */
-    private ?RRule $rrule;
+    private RRule $rrule;
 
     /**
      * @ORM\Column(type="integer")
      */
-    private ?int $duration;
+    private int $duration;
 
     /**
      * @ORM\ManyToOne(targetEntity=Playlist::class, inversedBy="schedules")
      * @ORM\JoinColumn(nullable=false)
      */
-    private ?Playlist $playlist;
+    private Playlist $playlist;
 
-    public function getRrule(): ?RRule
+    public function getRrule(): RRule
     {
         return $this->rrule;
     }
@@ -41,7 +41,7 @@ class Schedule
         return $this;
     }
 
-    public function getDuration(): ?int
+    public function getDuration(): int
     {
         return $this->duration;
     }
@@ -53,12 +53,12 @@ class Schedule
         return $this;
     }
 
-    public function getPlaylist(): ?Playlist
+    public function getPlaylist(): Playlist
     {
         return $this->playlist;
     }
 
-    public function setPlaylist(?Playlist $playlist): self
+    public function setPlaylist(Playlist $playlist): self
     {
         $this->playlist = $playlist;
 

--- a/src/Repository/ScheduleRepository.php
+++ b/src/Repository/ScheduleRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Schedule;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Schedule|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Schedule|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Schedule[]    findAll()
+ * @method Schedule[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ScheduleRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Schedule::class);
+    }
+
+    // /**
+    //  * @return Schedule[] Returns an array of Schedule objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('s')
+            ->andWhere('s.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('s.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?Schedule
+    {
+        return $this->createQueryBuilder('s')
+            ->andWhere('s.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/tests/Api/PlaylistsTest.php
+++ b/tests/Api/PlaylistsTest.php
@@ -51,7 +51,7 @@ class PlaylistsTest extends ApiTestCase
                 'hydra' => 'http://www.w3.org/ns/hydra/core#',
                 'title' => 'Playlist/title',
                 'description' => 'Playlist/description',
-                'schedule' => 'Playlist/schedule',
+                'schedules' => 'Playlist/schedules',
                 'created' => 'Playlist/created',
                 'modified' => 'Playlist/modified',
                 'modifiedBy' => 'Playlist/modifiedBy',
@@ -69,7 +69,16 @@ class PlaylistsTest extends ApiTestCase
             'json' => [
                 'title' => 'Test playlist',
                 'description' => 'This is a test playlist',
-                'schedule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                'schedules' => [
+                    [
+                        'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                        'duration' => 1000,
+                    ],
+                    [
+                        'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                        'duration' => 2000,
+                    ],
+                ],
                 'modifiedBy' => 'Test Tester',
                 'createdBy' => 'Hans Tester',
                 'published' => [
@@ -90,7 +99,7 @@ class PlaylistsTest extends ApiTestCase
                 'hydra' => 'http://www.w3.org/ns/hydra/core#',
                 'title' => 'Playlist/title',
                 'description' => 'Playlist/description',
-                'schedule' => 'Playlist/schedule',
+                'schedules' => 'Playlist/schedules',
                 'created' => 'Playlist/created',
                 'modified' => 'Playlist/modified',
                 'modifiedBy' => 'Playlist/modifiedBy',
@@ -100,7 +109,16 @@ class PlaylistsTest extends ApiTestCase
             '@type' => 'Playlist',
             'title' => 'Test playlist',
             'description' => 'This is a test playlist',
-            'schedule' => 'DTSTART:20211102T232610Z\\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+            'schedules' => [
+                [
+                    'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                    'duration' => 1000,
+                ],
+                [
+                    'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                    'duration' => 2000,
+                ],
+            ],
             'modifiedBy' => 'Test Tester',
             'createdBy' => 'Hans Tester',
             'published' => [
@@ -114,7 +132,16 @@ class PlaylistsTest extends ApiTestCase
             'json' => [
                 'title' => 'Test playlist',
                 'description' => 'This is a test playlist',
-                'schedule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                'schedules' => [
+                    [
+                        'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                        'duration' => 1000,
+                    ],
+                    [
+                        'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                        'duration' => 2000,
+                    ],
+                ],
                 'modifiedBy' => 'Test Tester',
                 'createdBy' => 'Hans Tester',
                 'published' => [
@@ -135,7 +162,7 @@ class PlaylistsTest extends ApiTestCase
                 'hydra' => 'http://www.w3.org/ns/hydra/core#',
                 'title' => 'Playlist/title',
                 'description' => 'Playlist/description',
-                'schedule' => 'Playlist/schedule',
+                'schedules' => 'Playlist/schedules',
                 'created' => 'Playlist/created',
                 'modified' => 'Playlist/modified',
                 'modifiedBy' => 'Playlist/modifiedBy',
@@ -145,7 +172,16 @@ class PlaylistsTest extends ApiTestCase
             '@type' => 'Playlist',
             'title' => 'Test playlist',
             'description' => 'This is a test playlist',
-            'schedule' => 'DTSTART:20211102T232610Z\\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+            'schedules' => [
+                [
+                    'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                    'duration' => 1000,
+                ],
+                [
+                    'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                    'duration' => 2000,
+                ],
+            ],
             'modifiedBy' => 'Test Tester',
             'createdBy' => 'Hans Tester',
             'published' => [
@@ -165,7 +201,16 @@ class PlaylistsTest extends ApiTestCase
             'json' => [
                 'title' => 'Test playlist',
                 'description' => 'This is a test playlist',
-                'schedule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                'schedules' => [
+                    [
+                        'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                        'duration' => 1000,
+                    ],
+                    [
+                        'rrule' => 'DTSTART:20211102T232610Z\nRRULE:FREQ=MINUTELY;COUNT=11;INTERVAL=8',
+                        'duration' => 2000,
+                    ],
+                ],
                 'modifiedBy' => 'Test Tester',
                 'createdBy' => 'Hans Tester',
                 'published' => [


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/AR-692

#### Description

- Changed playlist.schedule to playlist.schedules, which is an array of Schedule entities.

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
