### PR TITLE
AR-754: Set id before calling persist

### DIFF
--- a/src/Command/LoadScreenLayoutsCommand.php
+++ b/src/Command/LoadScreenLayoutsCommand.php
@@ -34,6 +34,7 @@ class LoadScreenLayoutsCommand extends Command
     final protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $successMessage = 'Screen layout updated';
 
         try {
             $filename = $input->getArgument('filename');
@@ -41,9 +42,9 @@ class LoadScreenLayoutsCommand extends Command
 
             if (isset($content->id) && Ulid::isValid($content->id)) {
                 $repository = $this->entityManager->getRepository(ScreenLayout::class);
-                $loadedScreenLayout = $repository->findOneBy(['id' => Ulid::fromString($content->id)]);
+                $screenLayout = $repository->findOneBy(['id' => Ulid::fromString($content->id)]);
 
-                if (!$loadedScreenLayout) {
+                if (!$screenLayout) {
                     $screenLayout = new ScreenLayout();
                     $metadata = $this->entityManager->getClassMetaData(get_class($screenLayout));
                     $metadata->setIdGenerator(new AssignedGenerator());
@@ -54,8 +55,7 @@ class LoadScreenLayoutsCommand extends Command
                     $screenLayout->setCreatedAt(\DateTime::createFromImmutable($ulid->getDateTime()));
 
                     $this->entityManager->persist($screenLayout);
-                } else {
-                    $screenLayout = $loadedScreenLayout;
+                    $successMessage = 'Screen layout added';
                 }
             } else {
                 $io->error('The screen layout should have an id (ulid)');
@@ -77,7 +77,7 @@ class LoadScreenLayoutsCommand extends Command
 
             $this->entityManager->flush();
 
-            $io->success('Screen layout added');
+            $io->success($successMessage);
 
             return Command::SUCCESS;
         } catch (\JsonException $exception) {

--- a/src/Command/LoadScreenLayoutsCommand.php
+++ b/src/Command/LoadScreenLayoutsCommand.php
@@ -47,12 +47,13 @@ class LoadScreenLayoutsCommand extends Command
                     $screenLayout = new ScreenLayout();
                     $metadata = $this->entityManager->getClassMetaData(get_class($screenLayout));
                     $metadata->setIdGenerator(new AssignedGenerator());
-                    $this->entityManager->persist($screenLayout);
 
                     $ulid = Ulid::fromString($content->id);
 
                     $screenLayout->setId($ulid);
                     $screenLayout->setCreatedAt(\DateTime::createFromImmutable($ulid->getDateTime()));
+
+                    $this->entityManager->persist($screenLayout);
                 } else {
                     $screenLayout = $loadedScreenLayout;
                 }

--- a/src/Command/LoadTemplateCommand.php
+++ b/src/Command/LoadTemplateCommand.php
@@ -36,6 +36,7 @@ class LoadTemplateCommand extends Command
     final protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $successMessage = 'Template updated';
 
         try {
             $filename = $input->getArgument('filename');
@@ -79,8 +80,9 @@ class LoadTemplateCommand extends Command
 
                 $template->setId($ulid);
                 $template->setCreatedAt(\DateTime::createFromImmutable($ulid->getDateTime()));
-                
+
                 $this->entityManager->persist($template);
+                $successMessage = 'Template added';
             }
 
             $template->setIcon($content->icon);
@@ -91,8 +93,7 @@ class LoadTemplateCommand extends Command
 
             $this->entityManager->flush();
 
-            $id = $template->getId();
-            $io->success("Template added with id: ${id}");
+            $io->success($successMessage);
 
             return Command::SUCCESS;
         } catch (\JsonException $exception) {

--- a/src/Command/LoadTemplateCommand.php
+++ b/src/Command/LoadTemplateCommand.php
@@ -74,12 +74,13 @@ class LoadTemplateCommand extends Command
                 $template = new Template();
                 $metadata = $this->entityManager->getClassMetaData(get_class($template));
                 $metadata->setIdGenerator(new AssignedGenerator());
-                $this->entityManager->persist($template);
 
                 $ulid = Ulid::fromString($content->id);
 
                 $template->setId($ulid);
                 $template->setCreatedAt(\DateTime::createFromImmutable($ulid->getDateTime()));
+                
+                $this->entityManager->persist($template);
             }
 
             $template->setIcon($content->icon);


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/AR-754

#### Description

Moved `persist` call to after the `id`is set to avoid `missing an assigned ID` error

#### Screenshot of the result

No screenshot

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
