### PR TITLE
AR-795: Fixed composer install path

### DIFF
--- a/infrastructure/display-api-service/Dockerfile
+++ b/infrastructure/display-api-service/Dockerfile
@@ -10,7 +10,7 @@ RUN tar -zxf /tmp/app.tar --strip-components=1 -C ${APP_PATH} \
     && rm /tmp/app.tar
 
 # Add composer in from the official composer image (also alpine).
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR ${APP_PATH}
 
@@ -28,7 +28,7 @@ LABEL maintainer="ITK Dev <itkdev@mkb.aarhus.dk>"
 ENV APP_PATH=/var/www/html
 
 # Add composer needed to run last minut optimizations after config is loaded.
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 # Install the application.
 COPY --from=APP_BUILDER ${APP_PATH} ${APP_PATH}


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/AR-795

#### Description

Composer 2 is copied to the wrong path in the `itkdev/php8.0-fpm:alpine` image. So the the composer:1 binary is not overwritten. 

#### Screenshot of the result

No screenshot

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
