### PR TITLE
AR-611: Return tenant key as default value if if title and description if these are not set.

### DIFF
--- a/src/Entity/Tenant.php
+++ b/src/Entity/Tenant.php
@@ -73,6 +73,16 @@ class Tenant extends AbstractBaseEntity implements \JsonSerializable
         return $this;
     }
 
+    public function getTitle(): string
+    {
+        return empty($this->title) ? $this->tenantKey : $this->title;
+    }
+
+    public function getDescription(): string
+    {
+        return empty($this->description) ? $this->tenantKey : $this->description;
+    }
+
     public function jsonSerialize(): array
     {
         return [


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/AR-611

#### Description

Return tenant key as default value if if title and description if these are not set to enable proper display in the admin client

#### Screenshot of the result

Fixes user menu display top right

![MicrosoftTeams-image](https://user-images.githubusercontent.com/5631988/159666964-2304d40a-7cf1-44d0-8503-929d1edecc0a.png)

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
