### PR TITLE
Add docker-compose.override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ public/media/*
 
 xdebug.ini
 launch.json
+
+# Allow local docker-compose overrides
+docker-compose.override.yml


### PR DESCRIPTION
#### Link to ticket

None.

#### Description

We use local docker-compose.override.yml files to avoid making changes to the shared docker-compose.yml.

docker-compose.override.yml is currently not in `.gitignore` which means we have to remember to exclude it all the time.

This PR adds the file to `.gitignore`.

#### Screenshot of the result

N/A.

#### Checklist

N/A

The not having git track the override should not affect any tests.

#### Additional comments or questions

I assume we don't have any automation that relies on docker-compose.override.yml to be tracked by git.
