### PR TITLE
SERV-579: Change docker server's UID for deploy user to 1042 to avoid…

### DIFF
--- a/infrastructure/display-api-service/Dockerfile
+++ b/infrastructure/display-api-service/Dockerfile
@@ -45,6 +45,10 @@ COPY etc/ /etc/
 ADD https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64 /usr/local/bin/confd
 RUN chmod +x /usr/local/bin/confd
 
+# Add deploy use to match server.
+RUN addgroup -g 1042 deploy \
+&& adduser -G deploy -u 1042 -h /home/deploy -D deploy
+
 COPY  docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -19,6 +19,10 @@ COPY etc/ /etc/
 ADD https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64 /usr/local/bin/confd
 RUN chmod +x /usr/local/bin/confd
 
+# Add deploy use to match server.
+RUN addgroup -g 1042 deploy \
+&& adduser -G deploy -u 1042 -h /home/deploy -D deploy
+
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -19,10 +19,6 @@ COPY etc/ /etc/
 ADD https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64 /usr/local/bin/confd
 RUN chmod +x /usr/local/bin/confd
 
-# Add deploy use to match server.
-RUN addgroup -g 1042 deploy \
-&& adduser -G deploy -u 1042 -h /home/deploy -D deploy
-
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 


### PR DESCRIPTION
… id clash on prod environment

#### Link to ticket

Please add a link to the ticket being addressed by this change.

#### Description

Change docker server's UID for deploy user to 1042 to avoid id clash on prod environment

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
