### PR TITLE
DISPLAY-969: Fixed jwt ttl not set from config for ScreenUser

### DIFF
--- a/.env
+++ b/.env
@@ -46,13 +46,13 @@ APP_DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s.v\Z'
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=APP_JWT_PASSPHRASE
-JWT_TOKEN_TTL=3600
-JWT_SCREEN_TOKEN_TTL=86400
+JWT_TOKEN_TTL=3600 # 1 hour
+JWT_SCREEN_TOKEN_TTL=1296000 # 15 days
 ###< lexik/jwt-authentication-bundle ###
 
 ###> gesdinet/jwt-refresh-token-bundle ###
-JWT_REFRESH_TOKEN_TTL=7200
-JWT_SCREEN_REFRESH_TOKEN_TTL=2592000
+JWT_REFRESH_TOKEN_TTL=7200 # 2 hours
+JWT_SCREEN_REFRESH_TOKEN_TTL=2592000 # 30 days
 ###< gesdinet/jwt-refresh-token-bundle ###
 
 ###> itk-dev/openid-connect-bundle ###

--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,16 @@ PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 
 DATABASE_URL="mysql://root:password@mariadb:3306/db_test?serverVersion=mariadb-10.5.13"
+
+###> lexik/jwt-authentication-bundle ###
+JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
+JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
+JWT_PASSPHRASE=APP_JWT_PASSPHRASE
+JWT_TOKEN_TTL=1800 # 30 min
+JWT_SCREEN_TOKEN_TTL=43200 # 12 hours
+###< lexik/jwt-authentication-bundle ###
+
+###> gesdinet/jwt-refresh-token-bundle ###
+JWT_REFRESH_TOKEN_TTL=3600 # 1 hour
+JWT_SCREEN_REFRESH_TOKEN_TTL=86400 # 24 hours
+###< gesdinet/jwt-refresh-token-bundle ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- [#143](https://github.com/os2display/display-api-service/pull/143)
+  Fixed token ttl not set correctly for ScreenUsers
+- [#142](https://github.com/os2display/display-api-service/pull/142)
+  Make it possible to upload svg in api.
 
 ## [1.2.6] - 2023-03-24
 
-- [#139](https://github.com/os2display/display-api-service/pull/139)
+- [#141](https://github.com/os2display/display-api-service/pull/141)
   Readded redis to docker-compose.
 
 ## [1.2.5] - 2023-03-16

--- a/src/Entity/Interfaces/TenantScopedUserInterface.php
+++ b/src/Entity/Interfaces/TenantScopedUserInterface.php
@@ -12,4 +12,6 @@ interface TenantScopedUserInterface
     public function setActiveTenant(Tenant $activeTenant): self;
 
     public function getTenants(): Collection;
+
+    public function getUserRoleTenants(): Collection;
 }

--- a/src/Entity/ScreenUser.php
+++ b/src/Entity/ScreenUser.php
@@ -141,4 +141,15 @@ class ScreenUser extends AbstractTenantScopedEntity implements UserInterface, Te
     {
         return new ArrayCollection([$this->getScreen()->getTenant()]);
     }
+
+    public function getUserRoleTenants(): Collection
+    {
+        $userRoleTenant = new \stdClass();
+        $userRoleTenant->tenantKey = $this->getScreen()->getTenant()->getTenantKey();
+        $userRoleTenant->title = $this->getScreen()->getTenant()->getTitle();
+        $userRoleTenant->description = $this->getScreen()->getTenant()->getDescription();
+        $userRoleTenant->roles = $this->getRoles();
+
+        return new ArrayCollection([$userRoleTenant]);
+    }
 }

--- a/src/Security/EventListener/JWTCreatedListener.php
+++ b/src/Security/EventListener/JWTCreatedListener.php
@@ -2,6 +2,7 @@
 
 namespace App\Security\EventListener;
 
+use App\Entity\Interfaces\TenantScopedUserInterface;
 use App\Entity\ScreenUser;
 use App\Entity\User;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
@@ -30,14 +31,14 @@ class JWTCreatedListener
         $payload = $event->getData();
         $user = $event->getUser();
 
-        if (!$user instanceof User) {
+        if (!$user instanceof TenantScopedUserInterface) {
             return;
         }
 
         $payload['user'] = $user;
         $payload['tenants'] = $user->getUserRoleTenants()->toArray();
 
-        if (isset($payload['roles']) && in_array(ScreenUser::ROLE_SCREEN, $payload['roles'])) {
+        if ($user instanceof ScreenUser) {
             $now = time();
             $payload['exp'] = $now + $this->screenTokenTtl;
         }

--- a/tests/Api/AuthenticationUserTest.php
+++ b/tests/Api/AuthenticationUserTest.php
@@ -13,11 +13,11 @@ class AuthenticationUserTest extends ApiTestCase
 {
     use ReloadDatabaseTrait;
 
-    // .env:JWT_TOKEN_TTL=3600
-    public const ENV_JWT_TOKEN_TTL = 3600;
+    // .env.test:JWT_TOKEN_TTL=1800
+    public const ENV_JWT_TOKEN_TTL = 1800;
 
-    // .env:JWT_REFRESH_TOKEN_TTL=7200
-    public const ENV_JWT_REFRESH_TOKEN_TTL = 7200;
+    // .env.test:JWT_REFRESH_TOKEN_TTL=3600
+    public const ENV_JWT_REFRESH_TOKEN_TTL = 3600;
 
     public function testLogin(): void
     {
@@ -65,9 +65,9 @@ class AuthenticationUserTest extends ApiTestCase
         $this->assertEquals('ABC', $content->tenants[0]->tenantKey);
         $this->assertCount(1, $content->tenants[0]->roles);
         $this->assertEquals('ROLE_EDITOR', $content->tenants[0]->roles[0]);
-        $decoded = json_decode(base64_decode(str_replace('_', '/', str_replace('-', '+', explode('.', $content->token)[1]))));
 
         // Assert token ttl values
+        $decoded = json_decode(base64_decode(str_replace('_', '/', str_replace('-', '+', explode('.', $content->token)[1]))));
         $expectedJwt = $decoded->iat + self::ENV_JWT_TOKEN_TTL;
         $this->assertEquals($expectedJwt, $decoded->exp);
 


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/DISPLAY-969

#### Description

* Fixed jwt ttl not set from config for ScreenUser
* Updated test suite to catch bug if it is re-introduced
* Set non-default TTL values for tests to ensure we test configured values and not default values.

#### Screenshot of the result

N/A

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
