### PR TITLE
DISPLAY-1039: Release 1.4.0

### DIFF
--- a/.github/workflows/php_upgrade.yaml
+++ b/.github/workflows/php_upgrade.yaml
@@ -51,44 +51,6 @@ jobs:
       - name: Normalize composer files
         run: composer normalize --dry-run
 
-  php-cs-fixer:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ["8.2"]
-    name: PHP Coding Standards Fixer (PHP ${{ matrix.php }})
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup PHP, with composer and extensions
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php}}
-          extensions: apcu, ctype, iconv, imagick, json, redis, soap, xmlreader, zip
-          coverage: none
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ matrix.php }}-composer-
-
-      - name: Update Dependencies
-        run: composer update --ignore-platform-reqs
-
-      - name: Install Dependencies
-        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist --ignore-platform-reqs
-
-      - name: php-cs-fixer
-        run: PHP_CS_FIXER_IGNORE_ENV=true phpdbg -qrr ./vendor/bin/php-cs-fixer fix --dry-run
-
   phpunit:
     runs-on: ubuntu-latest
     services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.4.0] - 2023-09-14
 - [#160](https://github.com/os2display/display-api-service/pull/160)
   Added app:feed:list-feed-source command. Removed listing from app:feed:remove-feed-source command.
-- [#158](https://github.com/os2display/display-api-service/pull/158)
-  Added thumbnails for image resources
 - [#159](https://github.com/os2display/display-api-service/pull/159)
   Fixed sprintf issue.
+- [#158](https://github.com/os2display/display-api-service/pull/158)
+  Added thumbnails for image resources
 
 ## [1.3.2] - 2023-07-11
 - [#157](https://github.com/os2display/display-api-service/pull/157)


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/DISPLAY-1039

#### Description

##### Release 1.4.0

- [#160](https://github.com/os2display/display-api-service/pull/160)
  Added app:feed:list-feed-source command. Removed listing from app:feed:remove-feed-source command.
- [#159](https://github.com/os2display/display-api-service/pull/159)
  Fixed sprintf issue.
- [#158](https://github.com/os2display/display-api-service/pull/158)
  Added thumbnails for image resources

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
