### PR TITLE
#161: Disable RelationsModified listener when loading fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#185](https://github.com/os2display/display-api-service/pull/185)
+  - Disable RelationsModified listener when loading fixtures to optimize performance
 - [#181](https://github.com/os2display/display-api-service/pull/181)
   - Update minimum PHP version to 8.2 to support trait constants
   - Add 'relationsModified' timestamps on relevant entities and API resources.

--- a/src/DataFixtures/Loader/DoctrineOrmLoaderDecorator.php
+++ b/src/DataFixtures/Loader/DoctrineOrmLoaderDecorator.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\DataFixtures\Loader;
+
+use App\EventListener\RelationsModifiedAtListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Hautelook\AliceBundle\Loader\DoctrineOrmLoader;
+use Hautelook\AliceBundle\LoaderInterface as AliceBundleLoaderInterface;
+use Hautelook\AliceBundle\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+
+/**
+ * Decorator class for DoctrineOrmLoader.
+ *
+ * Disable the "postFlush" RelationsModifiedAtListener before loading fixtures to optimize performance. Then run the
+ * RelationsModified update queries one time when all fixtures are loaded.
+ *
+ * @implements AliceBundleLoaderInterface
+ * @implements LoggerAwareInterface
+ */
+#[AsDecorator(decorates: 'hautelook_alice.loader')]
+class DoctrineOrmLoaderDecorator implements AliceBundleLoaderInterface, LoggerAwareInterface
+{
+
+    public function __construct(private readonly DoctrineOrmLoader $decorated)
+    {
+    }
+
+    public function load(Application $application, EntityManagerInterface $manager, array $bundles, string $environment, bool $append, bool $purgeWithTruncate, bool $noBundles = false): array
+    {
+        $eventManager = $manager->getEventManager();
+
+        $listeners = $eventManager->getListeners('postFlush');
+        foreach ($listeners as $listener) {
+            if ($listener instanceof RelationsModifiedAtListener) {
+                $eventManager->removeEventListener('postFlush', $listener);
+            }
+        }
+
+        $result = $this->decorated->load($application, $manager, $bundles, $environment, $append, $purgeWithTruncate, $noBundles);
+
+        $this->applyRelationsModified($manager);
+
+        return $result;
+    }
+
+    public function withLogger(LoggerInterface $logger)
+    {
+        $this->decorated->withLogger($logger);
+    }
+
+    private function applyRelationsModified(EntityManagerInterface $manager): void
+    {
+        $connection = $manager->getConnection();
+
+        $sqlQueries = RelationsModifiedAtListener::getUpdateRelationsAtQueries(withWhereClause: false);
+
+        $rows = 0;
+        foreach ($sqlQueries as $sqlQuery) {
+            $stm = $connection->prepare($sqlQuery);
+            $rows += $stm->executeStatement();
+        }
+    }
+}


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban?tab=ticketdetails#/tickets/showTicket/165

#### Description

Disable RelationsModified listener when loading fixtures to optimize performance. Because the fixtures are loaded repeatedly when running the test suite this also improves the run time for the test suite.

#### Screenshot of the result

#### Before

```
$ time idc bin/phpunit --stop-on-failure
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

Testing 
................................................................. 65 / 96 ( 67%)
...............................                                   96 / 96 (100%)

Time: 03:48.111, Memory: 348.50 MB
```

#### After

```
$ time idc bin/phpunit
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

Testing 
................................................................. 65 / 96 ( 67%)
...............................                                   96 / 96 (100%)

Time: 02:30.541, Memory: 187.00 MB
```
#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
