### PR TITLE
398: Add doctrine migration to change media references from 'v1' to 'v2'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#199](https://github.com/os2display/display-api-service/pull/199)
+  - Add doctrine migration to change media references from API 'v1' to API 'v2' in slide content
 - [#198](https://github.com/os2display/display-api-service/pull/198)
   - Changed route prefix to v2.
 - [#197](https://github.com/os2display/display-api-service/pull/197)

--- a/migrations/Version20240405092445.php
+++ b/migrations/Version20240405092445.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
 /**
- * Update links to media in slide content field to match api version change
+ * Update links to media in slide content field to match api version change.
  */
 final class Version20240405092445 extends AbstractMigration
 {

--- a/migrations/Version20240405092445.php
+++ b/migrations/Version20240405092445.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Update links to media in slide content field to match api version change
+ */
+final class Version20240405092445 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update links to media in slide content field to match api version change';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE slide SET content = REPLACE(content, \'\\\/v1\\\/media\\\/\', \'\\\/v2\\\/media\\\/\')');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE slide SET content = REPLACE(content, \'\\\/v2\\\/media\\\/\', \'\\\/v1\\\/media\\\/\')');
+    }
+}


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/398

#### Description

Add doctrine migration to change media references from API 'v1' to API 'v2' in slide content. Example:
```
{"images":["\/v1\/media\/01G1R1GWYWGBWNDK83AMGR3WAQ","\/v1\/media\/01G1R1GX31VBARESFZAMPJDWRF","\/v1\/media\/01G1R1GXAR4SBN4HT12PBH6XER"],"imageDuration":5}
{"images":["\/v2\/media\/01G1R1GWYWGBWNDK83AMGR3WAQ","\/v2\/media\/01G1R1GX31VBARESFZAMPJDWRF","\/v2\/media\/01G1R1GXAR4SBN4HT12PBH6XER"],"imageDuration":5}
```

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
