### PR TITLE
1456: Fixed "parameter not set" in api image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#207](https://github.com/os2display/display-api-service/pull/207)
+  - Fixed parameter not set error in (os2display) api container.
+
 ## [2.0.4] - 2024-04-25
 
 - [#204](https://github.com/os2display/display-api-service/pull/204)

--- a/infrastructure/os2display/display-api-service/Dockerfile
+++ b/infrastructure/os2display/display-api-service/Dockerfile
@@ -151,4 +151,5 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 WORKDIR ${APP_PATH}
 
-CMD [ "docker-entrypoint.sh" ]
+CMD ["php-fpm"]
+ENTRYPOINT [ "docker-entrypoint.sh" ]

--- a/infrastructure/os2display/display-api-service/docker-entrypoint.sh
+++ b/infrastructure/os2display/display-api-service/docker-entrypoint.sh
@@ -17,6 +17,6 @@ if [ "${1#-}" != "$1" ]; then
 fi
 
 ## Start the PHP FPM process.
-echo "Starting PHP 8.2 FPM"
+echo "Starting PHP 8.3 FPM"
 
-exec php-fpm "$@"
+exec "$@"


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

Fixed parameter not set error in (os2display) api container
```
api-1        | /usr/local/bin/docker-entrypoint.sh: line 15: 1: parameter not set
api-1        | + /usr/local/bin/confd --onetime --backend env --confdir /etc/confd
```

See https://github.com/docker-library/php/issues/953

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
