### PR TITLE
2130: Add logging for authentication failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.8] - 2024-08-21
+
+- [#212](https://github.com/os2display/display-api-service/pull/212)
+  - Add logging for authentication failures
+
 ## [2.0.7] - 2024-08-20
 
 - [#211](https://github.com/os2display/display-api-service/pull/211)

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -65,9 +65,18 @@ services:
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_created, method: onJWTCreated }
 
+    App\Security\EventListener\AuthenticationFailureListener:
+        tags:
+            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_failure, method: onAuthenticationFailure }
+            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_invalid, method: onJwtInvalid }
+            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_not_found, method: onJwtNotFound }
+            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_expired, method: onJwtExpired }
+            - { name: kernel.event_listener, event: gesdinet.refresh_token_failure, method: onRefreshTokenFailure }
+            - { name: kernel.event_listener, event: gesdinet.refresh_token_not_found, method: onRefreshTokenNotFound }
+
     App\Security\EventListener\AuthenticationSuccessListener:
         tags:
-            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: onAuthenticationSuccessResponse }
+            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: onAuthenticationSuccess }
 
     app.tenant_scoped_authenticator:
         class: App\Security\TenantScopedAuthenticator

--- a/src/Security/EventListener/AuthenticationFailureListener.php
+++ b/src/Security/EventListener/AuthenticationFailureListener.php
@@ -61,11 +61,11 @@ readonly class AuthenticationFailureListener
 
         $data = [];
         $data['AuthenticationFailureListener'] = \get_class($event);
-        $data['request']['clientIp'] = $request->getClientIp();
-        $data['request']['pathInfo'] = $request->getPathInfo();
-        $data['request']['requestUri'] = $request->getRequestUri();
-        $data['request']['method'] = $request->getMethod();
-        $data['request']['referer'] = $request->headers->get('referer');
+        $data['request']['clientIp'] = $request?->getClientIp();
+        $data['request']['pathInfo'] = $request?->getPathInfo();
+        $data['request']['requestUri'] = $request?->getRequestUri();
+        $data['request']['method'] = $request?->getMethod();
+        $data['request']['referer'] = $request?->headers->get('referer');
 
         $this->logger->error('AuthenticationFailureListener', [
             'code' => $exception->getCode(),

--- a/src/Security/EventListener/AuthenticationFailureListener.php
+++ b/src/Security/EventListener/AuthenticationFailureListener.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\EventListener;
+
+use Gesdinet\JWTRefreshTokenBundle\Event\RefreshAuthenticationFailureEvent;
+use Gesdinet\JWTRefreshTokenBundle\Event\RefreshTokenNotFoundEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationFailureEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTExpiredEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class AuthenticationFailureListener.
+ *
+ * Class is responsible for logging authentication failure event details to aid in debugging screen clients that
+ * loose authentication.
+ */
+readonly class AuthenticationFailureListener
+{
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {}
+
+    public function onAuthenticationFailure(AuthenticationFailureEvent $event): void
+    {
+        $this->logJWTAuthenticationEvent($event);
+    }
+
+    public function onJwtInvalid(JWTInvalidEvent $event): void
+    {
+        $this->logJWTAuthenticationEvent($event);
+    }
+
+    public function onJwtNotFound(JWTNotFoundEvent $event): void
+    {
+        $this->logJWTAuthenticationEvent($event);
+    }
+
+    public function onJwtExpired(JWTExpiredEvent $event): void
+    {
+        $this->logJWTAuthenticationEvent($event);
+    }
+
+    public function onRefreshTokenFailure(RefreshAuthenticationFailureEvent $event): void
+    {
+        $this->logJWTRefreshEvent($event);
+    }
+
+    public function onRefreshTokenNotFound(RefreshTokenNotFoundEvent $event): void
+    {
+        $this->logJWTRefreshEvent($event);
+    }
+
+    private function logJWTAuthenticationEvent(AuthenticationFailureEvent $event): void
+    {
+        $request = $event->getRequest();
+        $exception = $event->getException();
+
+        $data = [];
+        $data['AuthenticationFailureListener'] = \get_class($event);
+        $data['request']['clientIp'] = $request->getClientIp();
+        $data['request']['pathInfo'] = $request->getPathInfo();
+        $data['request']['requestUri'] = $request->getRequestUri();
+        $data['request']['method'] = $request->getMethod();
+        $data['request']['referer'] = $request->headers->get('referer');
+
+        $this->logger->error('AuthenticationFailureListener', [
+            'code' => $exception->getCode(),
+            'message' => $exception->getMessage(),
+            'request' => $data,
+        ]);
+    }
+
+    private function logJWTRefreshEvent(RefreshAuthenticationFailureEvent|RefreshTokenNotFoundEvent $event): void
+    {
+        $exception = $event->getException();
+
+        $data = [];
+        $data['AuthenticationFailureListener'] = \get_class($event);
+        $data['request'] = 'Not available for JWT refresh failure events';
+
+        $this->logger->error('AuthenticationFailureListener', [
+            'code' => $exception->getCode(),
+            'message' => $exception->getMessage(),
+            'request' => $data,
+        ]);
+    }
+}

--- a/src/Security/EventListener/AuthenticationSuccessListener.php
+++ b/src/Security/EventListener/AuthenticationSuccessListener.php
@@ -14,7 +14,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
  */
 class AuthenticationSuccessListener
 {
-    public function onAuthenticationSuccessResponse(AuthenticationSuccessEvent $event): void
+    public function onAuthenticationSuccess(AuthenticationSuccessEvent $event): void
     {
         $data = $event->getData();
         $user = $event->getUser();


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/show?tab=timesheet#/tickets/showTicket/2130

#### Description

Add event listener to log JWT auth and renew failures to aid in debugging screens loosing auth.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
