### PR TITLE
2571: Make endSessionUrl nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#214](https://github.com/os2display/display-api-service/pull/214)
+  - Updated endSessionUrl to be nullable.
 - [#193](https://github.com/os2display/display-api-service/pull/193)
   - Adds support for interactive slides.
   - Adds interactivity for creating quick bookings from a slide through Microsoft Graph.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ classDiagram
 
 ## Development Setup
 
-A `docker-compose.yml` file with a PHP 8.0 image is included in this project.
+A `docker-compose.yml` file with a PHP 8.3 image is included in this project.
 To install the dependencies you can run
 
 ```shell

--- a/src/Controller/AuthOidcController.php
+++ b/src/Controller/AuthOidcController.php
@@ -72,7 +72,6 @@ class AuthOidcController extends AbstractController
             $session->set('oauth2state', $state);
             $session->set('oauth2nonce', $nonce);
 
-
             // We allow end session endpoint to not be set, by letting $endSessionUrl be null.
             // This is handled in the admin by removing the logout button.
             try {

--- a/src/Controller/AuthOidcController.php
+++ b/src/Controller/AuthOidcController.php
@@ -72,6 +72,15 @@ class AuthOidcController extends AbstractController
             $session->set('oauth2state', $state);
             $session->set('oauth2nonce', $nonce);
 
+
+            // We allow end session endpoint to not be set, by letting $endSessionUrl be null.
+            // This is handled in the admin by removing the logout button.
+            try {
+                $endSessionUrl = $provider->getEndSessionUrl();
+            } catch (ItkOpenIdConnectException $e) {
+                $endSessionUrl = null;
+            }
+
             $data = [
                 'authorizationUrl' => $provider->getAuthorizationUrl([
                     'state' => $state,
@@ -79,7 +88,7 @@ class AuthOidcController extends AbstractController
                     'response_type' => 'code',
                     'scope' => 'openid email profile',
                 ]),
-                'endSessionUrl' => $provider->getEndSessionUrl(),
+                'endSessionUrl' => $endSessionUrl,
             ];
 
             return new JsonResponse($data);

--- a/src/Controller/AuthOidcController.php
+++ b/src/Controller/AuthOidcController.php
@@ -72,8 +72,7 @@ class AuthOidcController extends AbstractController
             $session->set('oauth2state', $state);
             $session->set('oauth2nonce', $nonce);
 
-            // We allow end session endpoint to not be set, by letting $endSessionUrl be null.
-            // This is handled in the admin by removing the logout button.
+            // We allow end session endpoint to not be set.
             try {
                 $endSessionUrl = $provider->getEndSessionUrl();
             } catch (ItkOpenIdConnectException $e) {


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban?tab=ticketdetails#/tickets/showTicket/2571

#### Description

It should not be required to have a end session endpoint in openid connect setup.

#### Additional comments or questions

As this is a one-off it is handled directly in this project rather than in our openid-connect bundle and library.

__NOTE__: Failing checks are fixed in https://github.com/os2display/display-api-service/pull/213 by updating symfony packages.

