### PR TITLE
Notified Feed Type bug when media url is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#236](https://github.com/os2display/display-api-service/pull/236)
+  - Fixed bug where no media url made Notified feed crash.
 - [#231](https://github.com/os2display/display-api-service/pull/231)
   - Adds new feed source: Eventdatabasen v2.
 - [#233](https://github.com/os2display/display-api-service/pull/233)

--- a/src/Feed/NotifiedFeedType.php
+++ b/src/Feed/NotifiedFeedType.php
@@ -57,11 +57,15 @@ class NotifiedFeedType implements FeedTypeInterface
             // Check that image is available and accessible, otherwise leave out the feed element.
             foreach ($feedItems as $feedItem) {
                 if (!empty($feedItem['mediaUrl'])) {
-                    $response = $this->client->request(Request::METHOD_HEAD, $feedItem['mediaUrl']);
-                    $statusCode = $response->getStatusCode();
+                    try {
+                        $response = $this->client->request(Request::METHOD_HEAD, $feedItem['mediaUrl']);
+                        $statusCode = $response->getStatusCode();
 
-                    if (200 == $statusCode) {
-                        $result[] = $feedItem;
+                        if (200 === $statusCode) {
+                            $result[] = $feedItem;
+                        }
+                    } catch (\Exception) {
+                        // Ignore item if request fails.
                     }
                 }
             }

--- a/src/Feed/NotifiedFeedType.php
+++ b/src/Feed/NotifiedFeedType.php
@@ -54,15 +54,15 @@ class NotifiedFeedType implements FeedTypeInterface
 
             $result = [];
 
-            // Check that image is accessible, otherwise leave out the feed element.
+            // Check that image is available and accessible, otherwise leave out the feed element.
             foreach ($feedItems as $feedItem) {
                 if (!empty($feedItem['mediaUrl'])) {
                     $response = $this->client->request(Request::METHOD_HEAD, $feedItem['mediaUrl']);
-                }
-                $statusCode = $response->getStatusCode();
+                    $statusCode = $response->getStatusCode();
 
-                if (200 == $statusCode) {
-                    $result[] = $feedItem;
+                    if (200 == $statusCode) {
+                        $result[] = $feedItem;
+                    }
                 }
             }
 

--- a/src/Feed/NotifiedFeedType.php
+++ b/src/Feed/NotifiedFeedType.php
@@ -56,7 +56,9 @@ class NotifiedFeedType implements FeedTypeInterface
 
             // Check that image is accessible, otherwise leave out the feed element.
             foreach ($feedItems as $feedItem) {
-                $response = $this->client->request(Request::METHOD_HEAD, $feedItem['mediaUrl']);
+                if (!empty($feedItem['mediaUrl'])) {
+                    $response = $this->client->request(Request::METHOD_HEAD, $feedItem['mediaUrl']);
+                }
                 $statusCode = $response->getStatusCode();
 
                 if (200 == $statusCode) {


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/3941

#### Description

Fixed bug where no media url made Notified feed crash.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
