### PR TITLE
Changed calendar api feed type to use display name from resources feed instead of events feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#242](https://github.com/os2display/display-api-service/pull/242)
+  - Changed calendar api feed type to use display name from resources feed instead of events feed.
+
 ## [2.5.0] - 2025-05-09
 
 - [#240](https://github.com/os2display/display-api-service/pull/240)

--- a/src/Feed/CalendarApiFeedType.php
+++ b/src/Feed/CalendarApiFeedType.php
@@ -79,7 +79,7 @@ class CalendarApiFeedType implements FeedTypeInterface
             $events = [];
 
             foreach ($requestedResources as $requestedResource) {
-                $events += $this->getResourceEvents($requestedResource);
+                $events = array_merge($events, $this->getResourceEvents($requestedResource));
             }
 
             $modifiedResults = static::applyModifiersToEvents($events, $this->eventModifiers, $enabledModifiers);

--- a/src/Feed/CalendarApiFeedType.php
+++ b/src/Feed/CalendarApiFeedType.php
@@ -52,8 +52,7 @@ class CalendarApiFeedType implements FeedTypeInterface
         private readonly string $dateFormat,
         private readonly string $timezone,
         private readonly int $cacheExpireSeconds,
-    )
-    {
+    ) {
         $this->mappings = $this->createMappings($this->customMappings);
     }
 
@@ -104,7 +103,7 @@ class CalendarApiFeedType implements FeedTypeInterface
             }, $modifiedResults);
 
             // Sort bookings by start time.
-            usort($resultsAsArray, fn(array $a, array $b) => $a['startTime'] > $b['startTime'] ? 1 : -1);
+            usort($resultsAsArray, fn (array $a, array $b) => $a['startTime'] > $b['startTime'] ? 1 : -1);
 
             return $resultsAsArray;
         } catch (\Throwable $throwable) {
@@ -227,24 +226,24 @@ class CalendarApiFeedType implements FeedTypeInterface
                     $resources = array_merge($resources, $locationResources);
                 }
 
-                $resourceOptions = array_map(fn(Resource $resource) => [
+                $resourceOptions = array_map(fn (Resource $resource) => [
                     'id' => Ulid::generate(),
                     'title' => $resource->displayName,
                     'value' => $resource->id,
                 ], $resources);
 
                 // Sort resource options by title.
-                usort($resourceOptions, fn($a, $b) => strcmp((string)$a['title'], (string)$b['title']));
+                usort($resourceOptions, fn ($a, $b) => strcmp((string) $a['title'], (string) $b['title']));
 
                 return $resourceOptions;
             } elseif ('locations' === $name) {
-                $locationOptions = array_map(fn(Location $location) => [
+                $locationOptions = array_map(fn (Location $location) => [
                     'id' => Ulid::generate(),
                     'title' => $location->displayName,
                     'value' => $location->id,
                 ], $this->loadLocations());
 
-                usort($locationOptions, fn($a, $b) => strcmp((string)$a['title'], (string)$b['title']));
+                usort($locationOptions, fn ($a, $b) => strcmp((string) $a['title'], (string) $b['title']));
 
                 return $locationOptions;
             }
@@ -292,12 +291,12 @@ class CalendarApiFeedType implements FeedTypeInterface
 
     private function getResourceEvents(string $resourceId): array
     {
-        $cacheItem = $this->calendarApiCache->getItem(self::CACHE_KEY_EVENTS . '-' . $resourceId);
+        $cacheItem = $this->calendarApiCache->getItem(self::CACHE_KEY_EVENTS.'-'.$resourceId);
 
         if (!$cacheItem->isHit()) {
             $allEvents = $this->loadEvents();
 
-            $items = array_filter($allEvents, fn(CalendarEvent $item) => $item->resourceId === $resourceId);
+            $items = array_filter($allEvents, fn (CalendarEvent $item) => $item->resourceId === $resourceId);
 
             $cacheItem->set($items);
             $cacheItem->expiresAfter($this->cacheExpireSeconds);
@@ -309,12 +308,12 @@ class CalendarApiFeedType implements FeedTypeInterface
 
     private function getLocationResources(string $locationId): array
     {
-        $cacheItem = $this->calendarApiCache->getItem(self::CACHE_KEY_RESOURCES . '-' . $locationId);
+        $cacheItem = $this->calendarApiCache->getItem(self::CACHE_KEY_RESOURCES.'-'.$locationId);
 
         if (!$cacheItem->isHit()) {
             $allResources = $this->loadResources();
 
-            $items = array_filter($allResources, fn(Resource $item) => $item->locationId === $locationId);
+            $items = array_filter($allResources, fn (Resource $item) => $item->locationId === $locationId);
 
             $cacheItem->set($items);
             $cacheItem->expiresAfter($this->cacheExpireSeconds);
@@ -334,7 +333,7 @@ class CalendarApiFeedType implements FeedTypeInterface
 
                 $LocationEntries = $response->toArray();
 
-                $locations = array_map(fn(array $entry) => new Location(
+                $locations = array_map(fn (array $entry) => new Location(
                     $entry[$this->getMapping('locationId')],
                     $entry[$this->getMapping('locationDisplayName')],
                 ), $LocationEntries);
@@ -473,7 +472,7 @@ class CalendarApiFeedType implements FeedTypeInterface
 
     private function shouldFetchNewData(string $cacheKey): bool
     {
-        $latestRequestCacheItem = $this->calendarApiCache->getItem($cacheKey . self::CACHE_LATEST_REQUEST_SUFFIX);
+        $latestRequestCacheItem = $this->calendarApiCache->getItem($cacheKey.self::CACHE_LATEST_REQUEST_SUFFIX);
         $latestRequest = $latestRequestCacheItem->get();
 
         return null === $latestRequest || $latestRequest <= time() - $this->cacheExpireSeconds;


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/4423

#### Description

Changed calendar api feed type to use display name from resources feed instead of events feed.

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
