### PR TITLE
Changed resource name in calendar api feed type resource selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#243](https://github.com/os2display/display-api-service/pull/243)
+  - Changed resource name in calendar api feed type resource selector.
 - [#242](https://github.com/os2display/display-api-service/pull/242)
   - Changed calendar api feed type to use display name from resources feed instead of events feed.
 

--- a/docs/feed/calender-api-feed.md
+++ b/docs/feed/calender-api-feed.md
@@ -38,12 +38,14 @@ By default, the three endpoints should return data as follows:
     {
         "id": "Resource Id 1",
         "locationId": "Location Id 1",
+        "name": "Resource-1",
         "displayName": "Resource 1",
         "includedInEvents": true
     },
     {
         "id": "Resource Id 2",
         "locationId": "Location Id 1",
+        "name": "Resource-2",
         "displayName": "Resource 2",
         "includedInEvents": false
     }
@@ -52,7 +54,8 @@ By default, the three endpoints should return data as follows:
 
 * The `id` (Mapping key: RESOURCE_ID) should be unique for the resource.
 * The `locationId` (Mapping key: RESOURCE_LOCATION_ID) is the id of the location the resource belongs to.
-* The `displayName` (Mapping key: RESOURCE_DISPLAY_NAME) is the name the resource is presented by in templates and admin.
+* The `name` (Mapping key: RESOURCE_NAME) is the name the resource is presented by in the admin selector.
+* The `displayName` (Mapping key: RESOURCE_DISPLAY_NAME) is the name the resource is presented by in templates.
 * The `includedInEvents` (Mapping key: RESOURCE_INCLUDED_IN_EVENTS) determines if the resource is included in the events
 endpoint.
   This property can be excluded in the data. If this is the case, it defaults to `true`.
@@ -102,6 +105,7 @@ CALENDAR_API_FEED_SOURCE_CUSTOM_MAPPINGS='{
     "LOCATION_DISPLAY_NAME": "Example2",
     "RESOURCE_ID": "Example3",
     "RESOURCE_LOCATION_ID": "Example4",
+    "RESOURCE_NAME": "Example12",
     "RESOURCE_DISPLAY_NAME": "Example5",
     "RESOURCE_INCLUDED_IN_EVENTS": "Example6",
     "EVENT_TITLE": "Example7",

--- a/src/Feed/CalendarApiFeedType.php
+++ b/src/Feed/CalendarApiFeedType.php
@@ -228,7 +228,7 @@ class CalendarApiFeedType implements FeedTypeInterface
 
                 $resourceOptions = array_map(fn (Resource $resource) => [
                     'id' => Ulid::generate(),
-                    'title' => $resource->displayName,
+                    'title' => $resource->name . " (". $resource->displayName . ")",
                     'value' => $resource->id,
                 ], $resources);
 
@@ -372,6 +372,7 @@ class CalendarApiFeedType implements FeedTypeInterface
 
                         $resource = new Resource(
                             $id,
+                            $resourceEntry[$this->getMapping('resourceName')],
                             $resourceEntry[$this->getMapping('resourceLocationId')],
                             $resourceEntry[$this->getMapping('resourceDisplayName')],
                         );
@@ -485,6 +486,7 @@ class CalendarApiFeedType implements FeedTypeInterface
             'locationDisplayName' => $customMappings['LOCATION_DISPLAY_NAME'] ?? 'displayName',
             'resourceId' => $customMappings['RESOURCE_ID'] ?? 'id',
             'resourceLocationId' => $customMappings['RESOURCE_LOCATION_ID'] ?? 'locationId',
+            'resourceName' => $customMappings['RESOURCE_NAME'] ?? 'name',
             'resourceDisplayName' => $customMappings['RESOURCE_DISPLAY_NAME'] ?? 'displayName',
             'resourceIncludedInEvents' => $customMappings['RESOURCE_INCLUDED_IN_EVENTS'] ?? 'includedInEvents',
             'eventTitle' => $customMappings['EVENT_TITLE'] ?? 'title',

--- a/src/Feed/OutputModel/Calendar/Resource.php
+++ b/src/Feed/OutputModel/Calendar/Resource.php
@@ -8,6 +8,7 @@ class Resource
 {
     public function __construct(
         public string $id,
+        public string $name,
         public string $locationId,
         public string $displayName,
     ) {}


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/4573

#### Description

Changed resource name in calendar api feed type resource selector.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
