### PR TITLE
5365: rename grid to travel-grid

### DIFF
--- a/assets/shared/templates/travel.jsx
+++ b/assets/shared/templates/travel.jsx
@@ -155,7 +155,7 @@ function Travel({
 
   return (
     <IntlProvider messages={translations} locale="da" defaultLocale="da">
-      <div className="grid">
+      <div className="travel-grid">
         {(title || sanitizedtext || distance || timeFast || timeModerate) && (
           <div className={infoBoxClass}>
             <div className="header">

--- a/assets/shared/templates/travel/travel.scss
+++ b/assets/shared/templates/travel/travel.scss
@@ -3,7 +3,7 @@
   src: url("fontsubik-regular.woff") format("woff");
 }
 
-.grid {
+.travel-grid {
   font-family: "rubics", Helvetica, sans-serif;
   color: #343433;
   font-size: 1em;


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/5365

## And issue

https://github.com/os2display/display-api-service/issues/249

#### Description

- Rename `grid` to `travel-grid` as this was bleeding into other places named `grid`.

## Before

<img width="960" height="356" alt="image" src="https://github.com/user-attachments/assets/f8c1d7f8-909c-4d4e-80d9-7f472085d2ef" />


## After

<img width="969" height="327" alt="image" src="https://github.com/user-attachments/assets/f07bd7fb-f52a-4559-a0c9-6a9288012cfa" />

