### PR TITLE
SUGGESTION: replace playwright workflow with three playwright workflows (one for each asset directory)

### DIFF
--- a/.github/workflows/playwright_admin.yaml
+++ b/.github/workflows/playwright_admin.yaml
@@ -1,0 +1,50 @@
+on:
+  pull_request:
+    paths:
+      - "assets/admin/**"
+      - "assets/shared/**"
+
+name: Test
+
+env:
+  COMPOSE_USER: runner
+
+jobs:
+  frontend-build-and-test:
+    name: Playwright
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup network
+        run: docker network create frontend
+
+      - name: Composer install
+        run: |
+          docker compose run --rm phpfpm composer install
+
+      - name: Copy fixture assets to public/fixtures
+        run: |
+          docker compose run --rm phpfpm cp -r fixtures/public/fixtures public/fixtures
+
+      - name: Build assets
+        run: |
+          docker compose run --rm node npm install
+          docker compose run --rm node npm run build
+
+      - name: Run playwright
+        env:
+          CI: "true"
+        run: |
+          docker compose run --rm playwright npx playwright install --with-deps
+          docker compose run --rm playwright npx playwright test admin
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright_client.yaml
+++ b/.github/workflows/playwright_client.yaml
@@ -1,0 +1,50 @@
+on:
+  pull_request:
+    paths:
+      - "assets/client/**"
+      - "assets/shared/**"
+
+name: Test
+
+env:
+  COMPOSE_USER: runner
+
+jobs:
+  frontend-build-and-test:
+    name: Playwright
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup network
+        run: docker network create frontend
+
+      - name: Composer install
+        run: |
+          docker compose run --rm phpfpm composer install
+
+      - name: Copy fixture assets to public/fixtures
+        run: |
+          docker compose run --rm phpfpm cp -r fixtures/public/fixtures public/fixtures
+
+      - name: Build assets
+        run: |
+          docker compose run --rm node npm install
+          docker compose run --rm node npm run build
+
+      - name: Run playwright
+        env:
+          CI: "true"
+        run: |
+          docker compose run --rm playwright npx playwright install --with-deps
+          docker compose run --rm playwright npx playwright test client
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright_template.yaml
+++ b/.github/workflows/playwright_template.yaml
@@ -1,4 +1,8 @@
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - "assets/template/**"
+      - "assets/shared/**"
 
 name: Test
 
@@ -36,7 +40,7 @@ jobs:
           CI: "true"
         run: |
           docker compose run --rm playwright npx playwright install --with-deps
-          docker compose run --rm playwright npx playwright test
+          docker compose run --rm playwright npx playwright test template
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
#### Link to ticket

https://github.com/os2display/display-api-service/issues/249
https://leantime.itkdev.dk/#/tickets/showTicket/5317

#### Description

- Add GA workflow for changes in each folder, so if I make changes in `assets/admin/**` the playwright tests in `tests/admin` runs, and  if I make changes in `assets/tempalte/**` the playwright tests in `tests/template` runs, and so forth
- The tests all run on changes in shared

#### Tested here

https://github.com/os2display/display-api-service/pull/300
