### PR TITLE
Add prod override for cache.app to use Redis in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#376](https://github.com/os2display/display-api-service/pull/376)
+  - Add prod override for cache.app to use Redis in production.
+
 ## [2.6.1] - 2026-03-06
 
 - [#347](https://github.com/os2display/display-api-service/pull/347)

--- a/config/packages/prod/cache.yaml
+++ b/config/packages/prod/cache.yaml
@@ -1,0 +1,3 @@
+framework:
+    cache:
+        app: cache.adapter.redis


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/show?tab=ticketdetails#/tickets/showTicket/7154

#### Description

Add prod override for `cache.app` to use Redis in production. The login URLs fecthed for OIDC are cached in `cache.app`, currently this is cache in filesystem, even in prod.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
