### PR TITLE
Fix testUnlinkSlide finding same slide twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#383](https://github.com/os2display/display-api-service/pull/383)
+  - Fixed `testUnlinkSlide` using same slide for both lookups, causing "Relation not found" failure.
 - [#379](https://github.com/os2display/display-api-service/pull/379)
   - Ensure the http client has a default time out setting. Make it configurable in env.
 - [#376](https://github.com/os2display/display-api-service/pull/376)

--- a/tests/Api/PlaylistSlideTest.php
+++ b/tests/Api/PlaylistSlideTest.php
@@ -158,9 +158,9 @@ class PlaylistSlideTest extends AbstractBaseApiTestCase
         $iri = $this->findIriBy(Playlist::class, ['tenant' => $this->tenant]);
         $playlistUlid = $this->iriHelperUtils->getUlidFromIRI($iri);
 
-        $iri = $this->findIriBy(Slide::class, ['tenant' => $this->tenant]);
+        $iri = $this->findIriBy(Slide::class, ['tenant' => $this->tenant, 'title' => 'slide_abc_2']);
         $slideUlid1 = $this->iriHelperUtils->getUlidFromIRI($iri);
-        $iri = $this->findIriBy(Slide::class, ['tenant' => $this->tenant]);
+        $iri = $this->findIriBy(Slide::class, ['tenant' => $this->tenant, 'title' => 'slide_abc_3']);
         $slideUlid2 = $this->iriHelperUtils->getUlidFromIRI($iri);
 
         // First create relations to ensure they exist before deleting theme.


### PR DESCRIPTION
## Summary

- Fix `PlaylistSlideTest::testUnlinkSlide` which has been failing on develop
- Root cause: `findIriBy(Slide::class, ['tenant' => $this->tenant])` was called twice with identical criteria, returning the same slide both times. The PUT created only one relation (duplicate slide entries), the first DELETE removed it, and the second DELETE failed with "Relation not found"
- Fix: use distinct slide titles (`slide_abc_2`, `slide_abc_3`) matching the pattern used in `testLinkSlideToPlaylist`

## Test plan

- [x] `testUnlinkSlide` passes locally
- [x] All 5 tests in `PlaylistSlideTest` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)