### PR TITLE
Fixed feed errors resulting in long caching of empty arrays for getData calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
   - Ensure the http client has a default time out setting. Make it configurable in env.
 - [#376](https://github.com/os2display/display-api-service/pull/376)
   - Add prod override for cache.app to use Redis in production.
+- [#386](https://github.com/os2display/display-api-service/pull/386)
+  - Add better cache handling when getData throws errors.
 
 ## [2.6.1] - 2026-03-06
 

--- a/src/Feed/BrndFeedType.php
+++ b/src/Feed/BrndFeedType.php
@@ -90,11 +90,9 @@ class BrndFeedType implements FeedTypeInterface
             }, []);
         } catch (\Throwable $throwable) {
             $this->logger->error($throwable->getMessage());
-            // Silently catch all exceptions and return empty result
-            // $result is already initialized with empty bookings array
-        }
 
-        return $result;
+            throw $throwable;
+        }
     }
 
     private function parseBrndBooking(array $booking): array

--- a/src/Feed/BrndFeedType.php
+++ b/src/Feed/BrndFeedType.php
@@ -78,7 +78,7 @@ class BrndFeedType implements FeedTypeInterface
 
             $bookings = $this->apiClient->getInfomonitorBookingsDetails($feedSource, $sportCenterId);
 
-            $result['bookings'] = array_reduce($bookings, function (array $carry, array $booking): array {
+            return array_reduce($bookings, function (array $carry, array $booking): array {
                 $parsedBooking = $this->parseBrndBooking($booking);
 
                 // Validate that booking has required fields

--- a/src/Feed/CalendarApiFeedType.php
+++ b/src/Feed/CalendarApiFeedType.php
@@ -67,9 +67,7 @@ class CalendarApiFeedType implements FeedTypeInterface
             $enabledModifiers = $configuration['enabledModifiers'] ?? [];
 
             if (!isset($configuration['resources'])) {
-                $this->logger->error('CalendarApiFeedType: Resources not set.');
-
-                return [];
+                throw new \RuntimeException('CalendarApiFeedType: Resources not set.');
             }
 
             $requestedResources = $configuration['resources'];

--- a/src/Feed/CalendarApiFeedType.php
+++ b/src/Feed/CalendarApiFeedType.php
@@ -114,9 +114,9 @@ class CalendarApiFeedType implements FeedTypeInterface
                 'message' => $throwable->getMessage(),
                 'exception' => $throwable,
             ]);
-        }
 
-        return [];
+            throw $throwable;
+        }
     }
 
     public static function applyModifiersToEvents(array $events, array $eventModifiers, array $enabledModifiers): array

--- a/src/Feed/EventDatabaseApiFeedType.php
+++ b/src/Feed/EventDatabaseApiFeedType.php
@@ -38,7 +38,7 @@ class EventDatabaseApiFeedType implements FeedTypeInterface
             $configuration = $feed->getConfiguration();
 
             if (!isset($secrets['host'])) {
-                return [];
+                throw new \RuntimeException('EventDatabaseApiFeedType: Host secret is not set.');
             }
 
             $host = $secrets['host'];
@@ -121,8 +121,14 @@ class EventDatabaseApiFeedType implements FeedTypeInterface
 
                             return [$eventOccurrence];
                         }
+
+                        throw new \RuntimeException('EventDatabaseApiFeedType: singleSelectedOccurrence is not set.');
+                    default:
+                        throw new \RuntimeException(sprintf('EventDatabaseApiFeedType: Unsupported posterType "%s".', $configuration['posterType']));
                 }
             }
+
+            throw new \RuntimeException('EventDatabaseApiFeedType: posterType is not set.');
         } catch (\Throwable $throwable) {
             // If the content does not exist anymore, unpublished the slide.
             if ($throwable instanceof ClientException && Response::HTTP_NOT_FOUND == $throwable->getCode()) {

--- a/src/Feed/EventDatabaseApiFeedType.php
+++ b/src/Feed/EventDatabaseApiFeedType.php
@@ -148,9 +148,9 @@ class EventDatabaseApiFeedType implements FeedTypeInterface
                     'message' => $throwable->getMessage(),
                 ]);
             }
-        }
 
-        return [];
+            throw $throwable;
+        }
     }
 
     /**

--- a/src/Feed/EventDatabaseApiV2FeedType.php
+++ b/src/Feed/EventDatabaseApiV2FeedType.php
@@ -57,7 +57,7 @@ class EventDatabaseApiV2FeedType implements FeedTypeInterface
                 }
 
                 if (!isset($configuration['posterType'])) {
-                    return [];
+                    throw new \RuntimeException('EventDatabaseApiV2FeedType: posterType is not set.');
                 }
 
                 return match ($configuration['posterType']) {

--- a/src/Feed/EventDatabaseApiV2FeedType.php
+++ b/src/Feed/EventDatabaseApiV2FeedType.php
@@ -95,9 +95,9 @@ class EventDatabaseApiV2FeedType implements FeedTypeInterface
                     'exception' => $throwable,
                 ]);
             }
-        }
 
-        return [];
+            throw $throwable;
+        }
     }
 
     private function getSubscriptionPosterOutput(FeedSource $feedSource, array $configuration): array

--- a/src/Feed/KobaFeedType.php
+++ b/src/Feed/KobaFeedType.php
@@ -38,9 +38,7 @@ class KobaFeedType implements FeedTypeInterface
             $configuration = $feed->getConfiguration();
 
             if (!isset($secrets['kobaHost']) || !isset($secrets['kobaApiKey'])) {
-                $this->logger->error('KobaFeedType: "Host" and "ApiKey" not configured.');
-
-                return [];
+                throw new \RuntimeException('KobaFeedType: "Host" and "ApiKey" not configured.');
             }
 
             $kobaHost = $secrets['kobaHost'];
@@ -50,9 +48,7 @@ class KobaFeedType implements FeedTypeInterface
             $rewriteBookedTitles = $configuration['rewriteBookedTitles'] ?? false;
 
             if (!isset($configuration['resources'])) {
-                $this->logger->error('KobaFeedType: Resources not set.');
-
-                return [];
+                throw new \RuntimeException('KobaFeedType: Resources not set.');
             }
 
             $resources = $configuration['resources'];

--- a/src/Feed/KobaFeedType.php
+++ b/src/Feed/KobaFeedType.php
@@ -121,9 +121,9 @@ class KobaFeedType implements FeedTypeInterface
                 'code' => $throwable->getCode(),
                 'message' => $throwable->getMessage(),
             ]);
-        }
 
-        return [];
+            throw $throwable;
+        }
     }
 
     /**

--- a/src/Feed/NotifiedFeedType.php
+++ b/src/Feed/NotifiedFeedType.php
@@ -32,12 +32,12 @@ class NotifiedFeedType implements FeedTypeInterface
         try {
             $secrets = $feed->getFeedSource()?->getSecrets();
             if (!isset($secrets['token'])) {
-                return [];
+                throw new \RuntimeException('NotifiedFeedType: Token secret is not set.');
             }
 
             $configuration = $feed->getConfiguration();
             if (!isset($configuration['feeds']) || 0 === count($configuration['feeds'])) {
-                return [];
+                throw new \RuntimeException('NotifiedFeedType: Feeds configuration is not set.');
             }
 
             $slide = $feed->getSlide();

--- a/src/Feed/NotifiedFeedType.php
+++ b/src/Feed/NotifiedFeedType.php
@@ -75,9 +75,9 @@ class NotifiedFeedType implements FeedTypeInterface
                 'code' => $throwable->getCode(),
                 'message' => $throwable->getMessage(),
             ]);
-        }
 
-        return [];
+            throw $throwable;
+        }
     }
 
     /**

--- a/src/Feed/RssFeedType.php
+++ b/src/Feed/RssFeedType.php
@@ -45,7 +45,7 @@ class RssFeedType implements FeedTypeInterface
             $url = $configuration['url'] ?? null;
 
             if (!isset($url)) {
-                return [];
+                throw new \RuntimeException('RssFeedType: URL is not set.');
             }
 
             $feedResult = $this->feedIo->read($url);

--- a/src/Feed/RssFeedType.php
+++ b/src/Feed/RssFeedType.php
@@ -74,9 +74,9 @@ class RssFeedType implements FeedTypeInterface
             return $result;
         } catch (\Throwable $throwable) {
             $this->logger->error($throwable->getCode().': '.$throwable->getMessage());
-        }
 
-        return [];
+            throw $throwable;
+        }
     }
 
     /**

--- a/src/Feed/SparkleIOFeedType.php
+++ b/src/Feed/SparkleIOFeedType.php
@@ -78,9 +78,9 @@ class SparkleIOFeedType implements FeedTypeInterface
                 'code' => $throwable->getCode(),
                 'message' => $throwable->getMessage(),
             ]);
-        }
 
-        return [];
+            throw $throwable;
+        }
     }
 
     /**

--- a/src/Feed/SparkleIOFeedType.php
+++ b/src/Feed/SparkleIOFeedType.php
@@ -41,12 +41,12 @@ class SparkleIOFeedType implements FeedTypeInterface
         try {
             $secrets = $feed->getFeedSource()?->getSecrets();
             if (!isset($secrets['baseUrl']) || !isset($secrets['clientId']) || !isset($secrets['clientSecret'])) {
-                return [];
+                throw new \RuntimeException('SparkleIOFeedType: Required secrets (baseUrl, clientId, clientSecret) are not set.');
             }
 
             $configuration = $feed->getConfiguration();
             if (!isset($configuration['feeds']) || 0 === count($configuration['feeds'])) {
-                return [];
+                throw new \RuntimeException('SparkleIOFeedType: Feeds configuration is not set.');
             }
 
             $baseUrl = $secrets['baseUrl'];

--- a/src/Service/FeedService.php
+++ b/src/Service/FeedService.php
@@ -15,6 +15,7 @@ use Symfony\Contracts\Cache\ItemInterface;
 
 class FeedService
 {
+    private const int ERROR_CACHE_TTL_SECONDS = 30;
     public function __construct(
         private readonly iterable $feedTypes,
         private readonly CacheInterface $feedsCache,
@@ -103,13 +104,25 @@ class FeedService
         /** @var FeedTypeInterface $feedType */
         foreach ($this->feedTypes as $feedType) {
             if ($feedType::class === $feedTypeClassName) {
-                return $this->feedsCache->get($feedId, function (ItemInterface $item) use ($feed, $feedType, $feedConfiguration) {
-                    if (isset($feedConfiguration['cache_expire'])) {
-                        $item->expiresAfter($feedConfiguration['cache_expire']);
-                    }
+                try {
+                    return $this->feedsCache->get($feedId, function (ItemInterface $item) use ($feed, $feedType, $feedConfiguration) {
+                        if (isset($feedConfiguration['cache_expire'])) {
+                            $item->expiresAfter($feedConfiguration['cache_expire']);
+                        }
 
-                    return $feedType->getData($feed);
-                });
+                        return $feedType->getData($feed);
+                    });
+                } catch (\Throwable) {
+                    // Cache empty result with a short TTL to prevent stampeding
+                    // the failing service with repeated requests.
+                    $this->feedsCache->delete($feedId);
+
+                    return $this->feedsCache->get($feedId, function (ItemInterface $item) {
+                        $item->expiresAfter(self::ERROR_CACHE_TTL_SECONDS);
+
+                        return [];
+                    });
+                }
             }
         }
 

--- a/src/Service/FeedService.php
+++ b/src/Service/FeedService.php
@@ -16,6 +16,7 @@ use Symfony\Contracts\Cache\ItemInterface;
 class FeedService
 {
     private const int ERROR_CACHE_TTL_SECONDS = 30;
+
     public function __construct(
         private readonly iterable $feedTypes,
         private readonly CacheInterface $feedsCache,

--- a/tests/HttpClient/LoggingHttpClientTest.php
+++ b/tests/HttpClient/LoggingHttpClientTest.php
@@ -27,7 +27,7 @@ class LoggingHttpClientTest extends TestCase
             ->with(
                 'info',
                 '{method} {url} {status_code} {duration}ms',
-                $this->callback(fn(array $context) => 'GET' === $context['method']
+                $this->callback(fn (array $context) => 'GET' === $context['method']
                     && 'https://example.com/api' === $context['url']
                     && 200 === $context['status_code']
                     && is_float($context['duration']))
@@ -73,7 +73,7 @@ class LoggingHttpClientTest extends TestCase
             ->method('error')
             ->with(
                 '{method} {url} failed after {duration}ms: {error}',
-                $this->callback(fn(array $context) => 'POST' === $context['method']
+                $this->callback(fn (array $context) => 'POST' === $context['method']
                     && 'https://example.com/fail' === $context['url']
                     && 'Connection refused' === $context['error']
                     && is_float($context['duration']))
@@ -150,7 +150,7 @@ class LoggingHttpClientTest extends TestCase
             ->with(
                 'info',
                 '{method} {url} {status_code} {duration}ms',
-                $this->callback(fn(array $context) => 500 === $context['status_code'])
+                $this->callback(fn (array $context) => 500 === $context['status_code'])
             );
 
         $client = new LoggingHttpClient($inner, $logger, 'info');

--- a/tests/HttpClient/LoggingHttpClientTest.php
+++ b/tests/HttpClient/LoggingHttpClientTest.php
@@ -27,12 +27,10 @@ class LoggingHttpClientTest extends TestCase
             ->with(
                 'info',
                 '{method} {url} {status_code} {duration}ms',
-                $this->callback(function (array $context) {
-                    return 'GET' === $context['method']
-                        && 'https://example.com/api' === $context['url']
-                        && 200 === $context['status_code']
-                        && is_float($context['duration']);
-                })
+                $this->callback(fn(array $context) => 'GET' === $context['method']
+                    && 'https://example.com/api' === $context['url']
+                    && 200 === $context['status_code']
+                    && is_float($context['duration']))
             );
 
         $client = new LoggingHttpClient($inner, $logger, 'info');
@@ -75,12 +73,10 @@ class LoggingHttpClientTest extends TestCase
             ->method('error')
             ->with(
                 '{method} {url} failed after {duration}ms: {error}',
-                $this->callback(function (array $context) {
-                    return 'POST' === $context['method']
-                        && 'https://example.com/fail' === $context['url']
-                        && 'Connection refused' === $context['error']
-                        && is_float($context['duration']);
-                })
+                $this->callback(fn(array $context) => 'POST' === $context['method']
+                    && 'https://example.com/fail' === $context['url']
+                    && 'Connection refused' === $context['error']
+                    && is_float($context['duration']))
             );
         // log() should NOT be called when the error path is taken
         $logger->expects($this->never())->method('log');
@@ -154,9 +150,7 @@ class LoggingHttpClientTest extends TestCase
             ->with(
                 'info',
                 '{method} {url} {status_code} {duration}ms',
-                $this->callback(function (array $context) {
-                    return 500 === $context['status_code'];
-                })
+                $this->callback(fn(array $context) => 500 === $context['status_code'])
             );
 
         $client = new LoggingHttpClient($inner, $logger, 'info');

--- a/tests/Service/FeedServiceTest.php
+++ b/tests/Service/FeedServiceTest.php
@@ -16,6 +16,7 @@ use App\Feed\SparkleIOFeedType;
 use App\Service\FeedService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -86,5 +87,86 @@ class FeedServiceTest extends KernelTestCase
         $data = $feedService->getData($feed);
 
         $this->assertEquals(['test' => 'test1'], $data);
+    }
+
+    public function testGetDataErrorIsNotCachedWithNormalTtl(): void
+    {
+        $mock = $this
+            ->getMockBuilder(FeedTypeInterface::class)
+            ->setMockClassName('FeedTypeErrorMock')
+            ->getMock();
+        $mock->method('getData')->willThrowException(new \RuntimeException('API unavailable'));
+
+        $cache = new ArrayAdapter();
+
+        $feedSource = new FeedSource();
+        $feedSource->setTitle('123');
+        $feedSource->setDescription('123');
+        $feedSource->setFeedType('FeedTypeErrorMock');
+        $this->entityManager->persist($feedSource);
+
+        $feed = new Feed();
+        $feed->setFeedSource($feedSource);
+        $feed->setConfiguration(['cache_expire' => 3600]);
+        $this->entityManager->persist($feed);
+
+        $feedService = new FeedService([$mock], $cache, $this->urlGenerator);
+
+        // First call should return empty array.
+        $data = $feedService->getData($feed);
+        $this->assertEquals([], $data);
+
+        // The empty result should be cached with a short TTL, not the normal 3600s.
+        // Verify by replacing the mock with one that returns data. If the error result
+        // were cached with the normal TTL, this would still return [].
+        $successMock = $this
+            ->getMockBuilder(FeedTypeInterface::class)
+            ->setMockClassName('FeedTypeErrorMock')
+            ->getMock();
+        $successMock->method('getData')->willReturn(['test' => 'success']);
+
+        $feedService = new FeedService([$successMock], $cache, $this->urlGenerator);
+
+        // Within the short TTL window, the cached empty result is returned.
+        $data = $feedService->getData($feed);
+        $this->assertEquals([], $data);
+    }
+
+    public function testGetDataErrorDoesNotCacheWithNormalTtl(): void
+    {
+        $callCount = 0;
+
+        $mock = $this
+            ->getMockBuilder(FeedTypeInterface::class)
+            ->setMockClassName('FeedTypeCountMock')
+            ->getMock();
+        $mock->method('getData')->willReturnCallback(function () use (&$callCount) {
+            ++$callCount;
+            throw new \RuntimeException('API unavailable');
+        });
+
+        // Use storeSerialized=false so TTL 0 entries expire immediately.
+        $cache = new ArrayAdapter(defaultLifetime: 0, storeSerialized: false);
+
+        $feedSource = new FeedSource();
+        $feedSource->setTitle('123');
+        $feedSource->setDescription('123');
+        $feedSource->setFeedType('FeedTypeCountMock');
+        $this->entityManager->persist($feedSource);
+
+        $feed = new Feed();
+        $feed->setFeedSource($feedSource);
+        $feed->setConfiguration(['cache_expire' => 3600]);
+        $this->entityManager->persist($feed);
+
+        $feedService = new FeedService([$mock], $cache, $this->urlGenerator);
+
+        // First call triggers getData.
+        $feedService->getData($feed);
+        $this->assertEquals(1, $callCount);
+
+        // Second call within TTL should use cached empty result, not call getData again.
+        $feedService->getData($feed);
+        $this->assertEquals(1, $callCount);
     }
 }


### PR DESCRIPTION
#### Link to issue

https://github.com/os2display/display-api-service/issues/377

#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/7201

#### Description

Fixed feed errors resulting in long caching of empty arrays for getData calls.

When CalendarApiFeedType::getData() (and other feed types) fail, they catch exceptions, log them, and return []. This empty array gets cached by FeedService::getData() via feedsCache->get(), serving the error result for the full cache duration. Symfony's cache contract skips caching if the callback throws.

Re-throw exceptions in feed types after logging, and catch them in FeedService::getData() outside the cache callback.

In the FeedService catch block, cache the empty result with a short TTL instead of just returning it uncached, to avoid stampede when getData throws an exception.

All return [] inside getData try blocks have been replaced with throws. Every path in getData now either returns data or throws an exception, which the catch block will log and re-throw, preventing the error from being cached with the normal TTL.

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
