### PR TITLE
Add BRND template to fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Optimized list loading.
 - Removed fixture length check from test.
 - Added vitest for frontend unit tests.
+- Add BRND template to fixtures.
 
 ### NB! Prior to 3.x the project was split into separate repositories
 

--- a/fixtures/template.yaml
+++ b/fixtures/template.yaml
@@ -6,6 +6,12 @@ App\Entity\Template:
     createdAt (unique): '<dateTimeBetween("-2 years", "-2 days")>'
     modifiedAt: '<dateTimeBetween($createdAt, "-1 days")>'
 
+  template_brnd:
+    id: '<ulidString("01K8TNT13XVCYYPXBJBBJVFENS")>'
+    title: "BRND"
+    createdAt (unique): '<dateTimeBetween("-2 years", "-2 days")>'
+    modifiedAt: '<dateTimeBetween($createdAt, "-1 days")>'
+
   template_calendar:
     id: '<ulidString("01FRJPF4XATRN8PBZ35XN84PS6")>'
     title: "Kalender"


### PR DESCRIPTION
#### Link to ticket
#406

#### Description
The only template that is not installed via fixtures is the BRND template. It is convinient to install that one as well.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

