### PR TITLE
370: Fix thumbnail 404 regression in nginx static-file location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - Removed fixture length check from test.
 - Added vitest for frontend unit tests.
 - Updated infrastructure and image build for mono-repo.
+- Fixed nginx static-file location to fall back to PHP so LiipImagineBundle can generate missing thumbnails (#370).
 
 ### NB! Prior to 3.x the project was split into separate repositories
 

--- a/infrastructure/nginx/etc/templates/default.conf.template
+++ b/infrastructure/nginx/etc/templates/default.conf.template
@@ -59,6 +59,7 @@ server {
         expires 1y;
         add_header Cache-Control "public, immutable";
         access_log off;
+        try_files $uri /index.php$is_args$args;
     }
 
     # Screen client online check should just serve static files


### PR DESCRIPTION
Refs #370.

## Summary
- The regex `location ~* \.(jpg|jpeg|png|gif|...)` block in `infrastructure/nginx/etc/templates/default.conf.template` wins over `location /` for any URL ending in `.jpg`. It had no `try_files` directive, so nginx fell back to the default `try_files $uri =404`. First-time requests to `/media/cache/resolve/<filter>/<path>.jpg` 404'd without ever calling PHP, breaking LiipImagineBundle thumbnail generation.
- One-line fix: add `try_files $uri /index.php$is_args$args;` to the static-file location so missing files hand off to Symfony, matching the implicit 2.6.1 behavior where everything flowed through `location /`.

## Why nginx, not PHP
Putting thumbnail resolution into a PHP-layer `file_get_contents` on the resolve URL would block the response thread on synchronous image processing per item, add per-collection-item latency on serialization, and tightly couple the DTO output layer to image generation. The nginx fallback is request-routed by the proxy, runs once per missing thumbnail (cached on disk thereafter), and keeps the API contract clean.

## Test plan
- [ ] Rebuild the nginx image from this branch.
- [ ] `curl -I https://<host>/media/cache/resolve/thumbnail/<path>.jpg` returns `302` (was `404`).
- [ ] Following the redirect returns `200` with `Cache-Control: public, immutable`.
- [ ] A second request to the original resolve URL returns the same redirect; subsequent direct requests to the resolved path hit the disk-cached file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)