### PR TITLE
390: Allow same-origin iframe embedding for admin previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ All notable changes to this project will be documented in this file.
 - Switched image build pipeline to GHCR with multi-arch layer caching.
 - Aligned the nginx image env-var contract: split `NGINX_FPM_SERVICE` and
   `NGINX_FPM_PORT`, raised upload cap and trusted-proxy CIDR defaults.
+- Allowed same-origin iframe embedding so the admin's screen/playlist
+  preview and fullscreen slide view work (#390).
 - Image build now writes `public/release.json` so the client's
   release-loader can fetch it. The same file is included in the GitHub
   Release tarball.

--- a/infrastructure/nginx/etc/templates/default.conf.template
+++ b/infrastructure/nginx/etc/templates/default.conf.template
@@ -23,7 +23,10 @@ server {
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
+    # frame-ancestors is the modern primary control; X-Frame-Options is
+    # defense-in-depth for pre-CSP-2 browsers (#390).
+    add_header Content-Security-Policy "frame-ancestors 'self'" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # Real IP from reverse proxy


### PR DESCRIPTION
Closes #390.

## Summary
The admin embeds the client via iframe to render screen/playlist previews and the fullscreen slide view. The nginx template was sending `X-Frame-Options: DENY`, so browsers refused to render the embedded iframe — exactly the failure shown in the issue's screenshot.

## Fix
Two-header approach in `infrastructure/nginx/etc/templates/default.conf.template`:

```nginx
add_header Content-Security-Policy "frame-ancestors 'self'" always;
add_header X-Frame-Options "SAMEORIGIN" always;
```

- **`Content-Security-Policy: frame-ancestors 'self'`** — the modern primary control. CSP Level 2+ is honored by every current browser and supersedes `X-Frame-Options` when both are present.
- **`X-Frame-Options: SAMEORIGIN`** — defense-in-depth for any pre-CSP-2 browser.

Both restrict iframe embedding to the same origin, which matches the docker-server compose layout where admin and client are served by the same nginx on the same hostname.

The `Content-Security-Policy` header here only sets `frame-ancestors`; it does not activate any other CSP rules and so doesn't risk breaking inline scripts or `eval`. Future CSP work can extend this header with additional directives without disturbing the iframe rule.

## Local validation
Built the nginx image from this branch and confirmed both headers are present in the rendered config:

```
$ docker run --rm --entrypoint sh local/display-api-service-nginx:390-test \
    -c '/docker-entrypoint.sh nginx -V >/dev/null 2>&1; grep -E "frame-ancestors|X-Frame-Options" /etc/nginx/conf.d/default.conf'
    add_header Content-Security-Policy "frame-ancestors 'self'" always;
    add_header X-Frame-Options "SAMEORIGIN" always;
```

## Test plan
- [ ] Rebuild nginx image; deploy or run locally.
- [ ] Open admin → screen detail → confirm preview iframe renders without "refused to display in a frame" browser console error.
- [ ] Open admin → playlist preview → same check.
- [ ] Open a slide → fullscreen view → same check.
- [ ] `curl -I` against any page response shows both `Content-Security-Policy: frame-ancestors 'self'` and `X-Frame-Options: SAMEORIGIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)