### PR TITLE
Fix Create Github Release workflow node_modules permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,7 @@
 
 # CI / quality-tool configs (not consumed at runtime)
 /phpstan.dist.neon
+/phpstan-baseline.neon
 /phpunit.xml.dist
 /psalm.xml
 /psalm-baseline.xml
@@ -65,7 +66,7 @@ launch.json
 /test-results/
 /playwright-report/
 /blob-report/
-/playwright/.cache/
+/playwright/
 #< Playwright
 
 ###> vincentlanglet/twig-cs-fixer ###

--- a/.github/workflows/github_build_release.yml
+++ b/.github/workflows/github_build_release.yml
@@ -38,10 +38,13 @@ jobs:
             composer install --no-dev -o --classmap-authoritative
           docker compose run --rm --env APP_ENV=prod phpfpm composer clear-cache
 
+      - name: Set compose node user
+        run: echo "COMPOSE_NODE_USER=$(id -u):$(id -g)" >> "$GITHUB_ENV"
+
       - name: NPM install and build
         run: |
-          docker compose run --rm node npm install
-          docker compose run --rm node npm run build
+          docker compose run --rm --env HOME=/tmp node npm install
+          docker compose run --rm --env HOME=/tmp node npm run build
 
       - name: Cleanup before packaging
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed `Create Github Release` workflow failing in `Cleanup before packaging` due to root-owned `node_modules` from the `node` compose service.
+
 ## [3.0.0-rc1] - 2026-05-04
 
 - Cleaned up and documented CI workflows; api-spec workflow now reports breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Fixed `Create Github Release` workflow failing in `Cleanup before packaging` due to root-owned `node_modules` from the `node` compose service.
+- Fixed `Create Github Release` workflow that failed cleanup because `node_modules/` was owned by root.
 
 ## [3.0.0-rc1] - 2026-05-04
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,6 +15,7 @@ services:
 
   node:
     image: node:24
+    user: "${COMPOSE_NODE_USER:-root}"
     command: npm run dev
     networks:
       - app


### PR DESCRIPTION
## Summary

Fixes the `Create Github Release` workflow failing at `Cleanup before packaging` because root-owned files from the `node` compose service could not be removed by the runner.

- Add overridable `user` to the `node` service (defaults to `root` so local-dev is unchanged).
- Set `COMPOSE_NODE_USER` to the runner's UID:GID and pass `HOME=/tmp` so npm can write its cache when not running as root.
- Align `.dockerignore` with the workflow's `Cleanup before packaging` list (`/phpstan-baseline.neon`, `/playwright/`).

Why scoped to a new `COMPOSE_NODE_USER` instead of reusing `COMPOSE_USER`: the `node:24` image has no built-in non-root user matching the runner UID, while `itkdev/php8.4-fpm:alpine` does (via `runner`). Reusing `COMPOSE_USER` would require touching the eleven other workflows that already rely on it for phpfpm.

## Test plan

- [x] Verified on a fork: tag push of `0.0.0-test3` produced a successful workflow run (1m31s), `Cleanup before packaging` passed, the GitHub release was created and assets (`*.tar.gz`, `checksum.txt`) uploaded.
- [ ] Confirm local `docker compose run node …` still works unchanged (root default preserved).
- [ ] Maintainer to push a real semver tag against `release/3.0.0` after merge to verify end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)