### PR TITLE
Restore container WORKDIR to /app (fixes JWT mount on 2.x→3.x upgrade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fixed `Create Github Release` workflow that failed cleanup because `node_modules/` was owned by root.
+- Restored container `WORKDIR` to `/app` (matches 2.x and the dev compose;
+  RC1 had drifted to `/var/www/html`, breaking JWT key mounts).
 
 ## [3.0.0-rc1] - 2026-05-04
 

--- a/infrastructure/Readme.md
+++ b/infrastructure/Readme.md
@@ -61,7 +61,7 @@ image as a `FROM` stage. The full pipeline:
    of npm/composer.
 
 5. **Build and push the nginx image.** Layers on `ghcr.io/os2display/display-api-service:<tag>` as the `app`
-   stage, `COPY`s `/var/www/html/public/` out of it, drops in the nginx config, and exposes a `/health`
+   stage, `COPY`s `/app/public/` out of it, drops in the nginx config, and exposes a `/health`
    endpoint. Pushed to `ghcr.io/os2display/display-api-service-nginx:<tag>`.
 
 For local `task images:build`, steps 4 and 5 run against the local docker daemon instead of the registry —

--- a/infrastructure/display-api-service/Dockerfile
+++ b/infrastructure/display-api-service/Dockerfile
@@ -45,7 +45,7 @@ USER root
 # whatever composer happens to ship in the FPM base.
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
-WORKDIR /var/www/html
+WORKDIR /app
 
 USER deploy
 
@@ -111,9 +111,9 @@ COPY --chmod=0755 docker-entrypoint.sh /usr/local/bin/
 
 USER deploy
 
-WORKDIR /var/www/html
+WORKDIR /app
 
-COPY --chown=deploy:deploy --from=api_app_builder /var/www/html .
+COPY --chown=deploy:deploy --from=api_app_builder /app .
 
 # Mount point for the Symfony secrets vault.
 RUN mkdir -p ./config/secrets

--- a/infrastructure/display-api-service/docker-entrypoint.sh
+++ b/infrastructure/display-api-service/docker-entrypoint.sh
@@ -7,6 +7,6 @@ set -eu
 composer dump-env prod
 
 ## Warm-up Symfony cache (with the current configuration).
-/var/www/html/bin/console --env=prod cache:warmup
+/app/bin/console --env=prod cache:warmup
 
 exec "$@"

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -21,13 +21,13 @@ ENV NGINX_PORT=8080 \
     NGINX_FPM_PORT=9000 \
     NGINX_MAX_BODY_SIZE=140m \
     NGINX_SET_REAL_IP_FROM=172.16.0.0/12 \
-    NGINX_WEB_ROOT=/var/www/html/public
+    NGINX_WEB_ROOT=/app/public
 
-WORKDIR /var/www/html
+WORKDIR /app
 
 # Single source of truth: public/ (incl. build/ and release.json) comes
 # from the just-published API image, not a duplicated builder stage.
-COPY --from=app --chown=$UID:0 --chmod=775 /var/www/html/public ./public
+COPY --from=app --chown=$UID:0 --chmod=775 /app/public ./public
 
 # Copy nginx configuration
 COPY --chown=$UID:0 etc /etc/nginx


### PR DESCRIPTION
## Summary

The 3.0.0-rc1 image rebuild silently moved `WORKDIR` from `/app` to `/var/www/html`. The 2.x image and every existing deployment's `docker-compose.yml` mount JWT keys and media at `/app/config/jwt` and `/app/public/media`. When the new image lands at `/var/www/html` instead, those mounts dangle and login breaks on the first OIDC token exchange with `JWTEncodeFailureException: Unable to create a signed JWT from the given configuration.` — no startup error, only on first authenticated user.

This PR restores `/app` so deployers can pull `3.0.0` over a working 2.x setup without rewriting their compose files.

## Changes

- `infrastructure/display-api-service/Dockerfile` — `WORKDIR` and the `COPY --from=api_app_builder` source path
- `infrastructure/display-api-service/docker-entrypoint.sh` — `bin/console` path in `cache:warmup`
- `infrastructure/nginx/Dockerfile` — `WORKDIR`, `NGINX_WEB_ROOT` default, and the `COPY --from=app` source path
- `infrastructure/Readme.md` — updated path reference
- `CHANGELOG.md` — Unreleased entry

After this, the only remaining `/var/www/html` strings in the repo are deliberate (e.g. unrelated docs/tests).

## Why `/app` over `/var/www/html`

`/app` matches:

- the published 2.x image (so existing deployments are unaffected)
- the local `docker-compose.yml` / `docker-compose.override.yml` in this repo (already on `/app`)
- the `os2display-docker-server-v3` deploy compose
- Symfony's own current Docker template (FrankenPHP-based, `/app`)
- ITK Dev's broader convention

The base image (`itkdev/php8.4-fpm`) defaults to `/var/www/html`, which is why RC1 drifted. We override it explicitly.

## Test plan

- [ ] `task images:build` produces an image where `WORKDIR` is `/app` and `bin/console` is at `/app/bin/console`
- [ ] Pull a new RC tag onto a 2.x deployment with no compose changes — login completes via OIDC
- [ ] Static assets and uploaded media still served correctly via the nginx container

🤖 Generated with [Claude Code](https://claude.com/claude-code)