### PR TITLE
Fixed Calendar and Colibo feed configuration urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed Calendar and Colibo feed configuration urls and added [] result when no locationEndpoint is set.
+
 ## [3.0.0-rc2] - 2026-05-05
 
 - Fixed `Create Github Release` workflow that failed cleanup because `node_modules/` was owned by root.

--- a/assets/admin/components/feed-sources/templates/calendar-api-feed-type.jsx
+++ b/assets/admin/components/feed-sources/templates/calendar-api-feed-type.jsx
@@ -16,7 +16,7 @@ const CalendarApiFeedType = ({
 
   useEffect(() => {
     if (feedSourceId && feedSourceId !== "") {
-      const endpoint = "/" + feedSourceId + "/config/locations";
+      const endpoint = `${feedSourceId}/config/locations`;
       setOptionsEndpoint(endpoint);
     }
   }, [feedSourceId]);

--- a/assets/admin/components/feed-sources/templates/colibo-feed-type.jsx
+++ b/assets/admin/components/feed-sources/templates/colibo-feed-type.jsx
@@ -18,7 +18,7 @@ const ColiboFeedType = ({
 
   useEffect(() => {
     if (feedSourceId && feedSourceId !== "") {
-      const endpoint = "/" + feedSourceId + "/config/recipients";
+      const endpoint = `${feedSourceId}/config/recipients`;
       setOptionsEndpoint(endpoint);
     }
   }, [feedSourceId]);

--- a/src/Feed/CalendarApiFeedType.php
+++ b/src/Feed/CalendarApiFeedType.php
@@ -300,6 +300,10 @@ class CalendarApiFeedType implements FeedTypeInterface
 
     private function getLocationOptions(): array
     {
+        if ('' === $this->locationEndpoint) {
+            return [];
+        }
+
         $locations = $this->loadLocations();
 
         return array_reduce($locations, function (array $carry, Location $location) {


### PR DESCRIPTION
#### Link to issue

https://github.com/os2display/display-api-service/issues/431

#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/7420

#### Description

Fixed Calendar and Colibo feed configuration urls and added [] result when no locationEndpoint is set.

NB! Playwright test that fails is unrelated.

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
