### PR TITLE
feat: Instant Book: Added strategy where busy intervals are retrieved from calendar feed

### DIFF
--- a/.env
+++ b/.env
@@ -165,6 +165,11 @@ CALENDAR_API_FEED_SOURCE_CACHE_EXPIRE_SECONDS=300
 EVENTDATABASE_API_V2_CACHE_EXPIRE_SECONDS=300
 ###< Event Database Api V2 Feed Type ###
 
+###> Instant Book ###
+# Source of busy intervals data for instant booking interactive slides (graph or feed).
+INSTANT_BOOK_BUSY_INTERVALS_SOURCE=graph
+###< Instant Book ###
+
 ###> Admin configuration ###
 # API key for Rejseplanen (Danish journey planner) integration.
 ADMIN_REJSEPLANEN_APIKEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Added `INSTANT_BOOK_BUSY_INTERVALS_SOURCE` to select between Graph and the slide's calendar feed as the source of busy
   intervals for InstantBook.
+- Changed polling interval for instant booking template.
 - Refactored InteractiveController to use a typed `InteractiveSlideActionInput` DTO; regenerated API spec and RTK types.
 - Fixed multiple InstantBook bugs: interval boundary overlap, busy-interval timezone, per-resource spam-protect
   throttling, duration validation, error responses (409/4xx), resource cache TTL, and assorted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added `INSTANT_BOOK_BUSY_INTERVALS_SOURCE` to select between Graph and the slide's calendar feed as the source of busy
+  intervals for InstantBook.
 - Refactored InteractiveController to use a typed `InteractiveSlideActionInput` DTO; regenerated API spec and RTK types.
 - Fixed multiple InstantBook bugs: interval boundary overlap, busy-interval timezone, per-resource spam-protect
   throttling, duration validation, error responses (409/4xx), resource cache TTL, and assorted

--- a/README.md
+++ b/README.md
@@ -577,6 +577,21 @@ EVENTDATABASE_API_V2_CACHE_EXPIRE_SECONDS=300
 - EVENTDATABASE_API_V2_CACHE_EXPIRE_SECONDS: What should the expiration be for cache entries in
   EventDatabaseApiV2FeedType?
 
+#### InstantBook
+
+```dotenv
+###> InstantBook ###
+INSTANT_BOOK_BUSY_INTERVALS_SOURCE=graph
+###< InstantBook ###
+```
+
+- INSTANT_BOOK_BUSY_INTERVALS_SOURCE: Where the InstantBook interactive slide fetches resource
+  busy-intervals from.
+  - `graph`: Fetch busy intervals from Microsoft Graph (results cached for 15 minutes).
+  - `feed`: Fetch busy intervals from the slide's configured calendar-output feed.
+
+  **Default**: `graph`.
+
 ## Rest API & Relationships
 
 To avoid embedding all relations in REST representations but still allow the clients to minimize the amount of API calls

--- a/assets/shared/templates/calendar/calendar-single-booking.jsx
+++ b/assets/shared/templates/calendar/calendar-single-booking.jsx
@@ -64,7 +64,6 @@ function CalendarSingleBooking({
   // Get values from client localstorage.
   const token = localStorage.getItem("apiToken");
   const tenantKey = localStorage.getItem("tenantKey");
-  const apiUrl = localStorage.getItem("apiUrl");
 
   const [bookableIntervals, setBookableIntervals] = useState([]);
   const [fetchingIntervals, setFetchingIntervals] = useState(false);
@@ -79,7 +78,7 @@ function CalendarSingleBooking({
       return;
     }
 
-    if (!apiUrl || !slide || !token || !tenantKey) {
+    if (!slide || !token || !tenantKey) {
       setFetchingIntervals(false);
       return;
     }
@@ -93,7 +92,7 @@ function CalendarSingleBooking({
     if (resources.length === 1) {
       setFetchingIntervals(true);
 
-      fetch(`${apiUrl}${slide["@id"]}/action`, {
+      fetch(`${slide["@id"]}/action`, {
         method: "POST",
         headers: {
           authorization: `Bearer ${token}`,
@@ -173,7 +172,7 @@ function CalendarSingleBooking({
   };
 
   const clickInterval = (interval) => {
-    if (!apiUrl || !slide || !token || !tenantKey) {
+    if (!slide || !token || !tenantKey) {
       return;
     }
 
@@ -183,7 +182,7 @@ function CalendarSingleBooking({
 
     setProcessingBooking(true);
 
-    fetch(`${apiUrl}${slide["@id"]}/action`, {
+    fetch(`${slide["@id"]}/action`, {
       method: "POST",
       headers: {
         authorization: `Bearer ${token}`,
@@ -217,7 +216,7 @@ function CalendarSingleBooking({
     dayjs.extend(localizedFormat);
 
     intervalChecking();
-    const interval = setInterval(intervalChecking, 5000);
+    const interval = setInterval(intervalChecking, 60000 * 2.5);
 
     return () => {
       if (interval !== null) {

--- a/assets/shared/templates/calendar/calendar-single-booking.jsx
+++ b/assets/shared/templates/calendar/calendar-single-booking.jsx
@@ -71,7 +71,7 @@ function CalendarSingleBooking({
   const [bookingResult, setBookingResult] = useState(null);
   const [processingBooking, setProcessingBooking] = useState(false);
   const [secondsUntilNextEvent, setSecondsUntilNextEvent] = useState(null);
-  const [bookingError, setBookingError] = useState(false);
+  const [bookingError, setBookingError] = useState(null);
 
   const fetchBookingIntervals = () => {
     if (!instantBookingEnabled) {
@@ -197,14 +197,21 @@ function CalendarSingleBooking({
         },
       }),
     })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) {
+          const error = new Error(`Booking failed with status ${r.status}`);
+          error.status = r.status;
+          throw error;
+        }
+        return r.json();
+      })
       .then((data) => {
         setBookingResult(data);
         setInstantBookingFromLocalStorage(slide["@id"], data);
       })
-      .catch(() => {
-        setBookingError(true);
-        setTimeout(() => setBookingError(false), 10000);
+      .catch((err) => {
+        setBookingError(err?.status === 409 ? "conflict" : "generic");
+        setTimeout(() => setBookingError(null), 10000);
       })
       .finally(() => {
         setProcessingBooking(false);
@@ -384,7 +391,15 @@ function CalendarSingleBooking({
                   />
                 </p>
               )}
-              {bookingError && (
+              {bookingError === "conflict" && (
+                <p>
+                  <FormattedMessage
+                    id="instant_booking_conflict"
+                    defaultMessage="Straksbooking fejlede. Intervallet er optaget."
+                  />
+                </p>
+              )}
+              {bookingError && bookingError !== "conflict" && (
                 <p>
                   <FormattedMessage
                     id="instant_booking_error"

--- a/assets/shared/templates/calendar/calendar-single-booking.jsx
+++ b/assets/shared/templates/calendar/calendar-single-booking.jsx
@@ -223,7 +223,8 @@ function CalendarSingleBooking({
     dayjs.extend(localizedFormat);
 
     intervalChecking();
-    const interval = setInterval(intervalChecking, 60000 * 2.5);
+    // Check every minute if the current time has changed.
+    const interval = setInterval(intervalChecking, 60000);
 
     return () => {
       if (interval !== null) {

--- a/assets/tests/template/template-calendar.spec.js
+++ b/assets/tests/template/template-calendar.spec.js
@@ -236,7 +236,7 @@ test("calendar-1-single-booking: ui tests", async ({ page }) => {
   await expect(page.getByText("Ledigt")).toHaveCount(1);
   await expect(page.getByText("Ledigt")).toBeVisible();
 
-  await page.waitForTimeout(5500);
+  await page.clock.runFor(61000);
 
   await expect(page.getByText("Optaget")).toHaveCount(1);
   await expect(page.getByText("Optaget")).toBeVisible();

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -98,6 +98,10 @@ services:
             $timezone: '%env(string:CALENDAR_API_FEED_SOURCE_DATE_TIMEZONE)%'
             $cacheExpireSeconds: '%env(int:CALENDAR_API_FEED_SOURCE_CACHE_EXPIRE_SECONDS)%'
 
+    App\InteractiveSlide\InstantBook:
+        arguments:
+            $busyIntervalsSource: '%env(string:INSTANT_BOOK_BUSY_INTERVALS_SOURCE)%'
+
     App\Service\KeyVaultService:
         arguments:
             $keyVaultSource: '%env(string:KEY_VAULT_SOURCE)%'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
-        <server name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
     <testsuites>

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -334,16 +334,7 @@ class InstantBook implements InteractiveSlideInterface
         $start = (new \DateTime())->setTimezone(new \DateTimeZone('UTC'));
         $startPlusDuration = (clone $start)->add(new \DateInterval('PT'.$durationMinutes.'M'))->setTimezone(new \DateTimeZone('UTC'));
 
-        // Pre-check the slot against live Graph state. This is required, not just an
-        // optimization: the resources used here are not configured to block conflicting
-        // bookings at the Graph API level — POSTing a conflicting booking will simply
-        // succeed rather than return 409. The 409 catch below is only a backstop for
-        // resources whose AutomateProcessing setting does reject conflicts.
-        $schedules = $this->getBusyIntervals($token, [$resource], $start, $startPlusDuration);
-
-        if (!$this->intervalFree($schedules[$resource] ?? [], $start, $startPlusDuration)) {
-            throw new ConflictException('Interval booked already');
-        }
+        $this->assertSlotFree($token, $resource, $start, $startPlusDuration);
 
         $requestBody = [
             'subject' => self::BOOKING_TITLE,
@@ -512,6 +503,25 @@ class InstantBook implements InteractiveSlideInterface
                 return $this->getBusyIntervals($token, $resources, $from, $to);
             },
         );
+    }
+
+    /**
+     * Verify that the requested slot is free in live Graph state before booking.
+     *
+     * This is required, not an optimization: the resources used here are not configured to block
+     * conflicting bookings at the Graph API level — POSTing a conflicting booking will simply
+     * succeed rather than return 409. The 409 catch on the booking POST is a backstop for
+     * resources whose AutomateProcessing setting does reject conflicts.
+     *
+     * @throws ConflictException if the slot is already booked
+     */
+    private function assertSlotFree(string $token, string $resource, \DateTime $start, \DateTime $end): void
+    {
+        $schedules = $this->getBusyIntervals($token, [$resource], $start, $end);
+
+        if (!$this->intervalFree($schedules[$resource] ?? [], $start, $end)) {
+            throw new ConflictException('Interval booked already');
+        }
     }
 
     /**

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\InteractiveSlide;
 
 use App\Entity\Tenant;
+use App\Entity\Tenant\Feed;
 use App\Entity\Tenant\InteractiveSlideConfig;
 use App\Entity\Tenant\Slide;
 use App\Exceptions\BadRequestException;
@@ -12,6 +13,8 @@ use App\Exceptions\ConflictException;
 use App\Exceptions\ForbiddenException;
 use App\Exceptions\NotAcceptableException;
 use App\Exceptions\TooManyRequestsException;
+use App\Feed\FeedOutputModels;
+use App\Service\FeedService;
 use App\Service\InteractiveSlideService;
 use App\Service\KeyVaultService;
 use Psr\Cache\CacheItemInterface;
@@ -45,6 +48,8 @@ class InstantBook implements InteractiveSlideInterface
     private const string CACHE_LIFETIME_QUICK_BOOK_OPTIONS = 'PT5M';
     private const string CACHE_LIFETIME_BUSY_INTERVALS = 'PT15M';
     private const string CACHE_LIFETIME_QUICK_BOOK_SPAM_PROTECT = 'PT1M';
+    public const string SOURCE_GRAPH = 'graph';
+    public const string SOURCE_FEED = 'feed';
     // see https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0
     // example 2019-03-15T09:00:00
     public const string GRAPH_DATE_FORMAT = 'Y-m-d\TH:i:s';
@@ -54,6 +59,8 @@ class InstantBook implements InteractiveSlideInterface
         private readonly HttpClientInterface $client,
         private readonly KeyVaultService $keyVaultService,
         private readonly CacheInterface $interactiveSlideCache,
+        private readonly FeedService $feedService,
+        private readonly string $busyIntervalsSource,
     ) {}
 
     public function getConfigOptions(): array
@@ -195,13 +202,7 @@ class InstantBook implements InteractiveSlideInterface
                         $watchedResources[] = $resource;
                     }
 
-                    $schedules = $this->interactiveSlideCache->get(self::CACHE_KEY_BUSY_INTERVALS_PREFIX,
-                        function (CacheItemInterface $item) use ($token, $watchedResources, $start, $startPlus1Hour) {
-                            $item->expiresAfter(new \DateInterval(self::CACHE_LIFETIME_BUSY_INTERVALS));
-
-                            return $this->getBusyIntervals($token, $watchedResources, $start, $startPlus1Hour);
-                        }
-                    );
+                    $schedules = $this->fetchBusyIntervals($token, $watchedResources, $start, $startPlus1Hour, $slide);
 
                     $result = [];
 
@@ -437,6 +438,89 @@ class InstantBook implements InteractiveSlideInterface
 
             $url = $data['@odata.nextLink'] ?? null;
         } while (null !== $url);
+
+        return $result;
+    }
+
+    /**
+     * Dispatch busy-intervals lookup according to INSTANT_BOOK_BUSY_INTERVALS_SOURCE.
+     *
+     * Both branches return the same shape:
+     * [resourceId => [['startTime' => DateTime, 'endTime' => DateTime], ...]].
+     *
+     * @param string[] $resources
+     *
+     * @throws \Throwable
+     */
+    private function fetchBusyIntervals(string $token, array $resources, \DateTime $from, \DateTime $to, Slide $slide): array
+    {
+        return match ($this->busyIntervalsSource) {
+            self::SOURCE_FEED => $this->getBusyIntervalsFromFeed($slide->getFeed(), $resources, $from, $to),
+            self::SOURCE_GRAPH => $this->interactiveSlideCache->get(
+                self::CACHE_KEY_BUSY_INTERVALS_PREFIX,
+                function (CacheItemInterface $item) use ($token, $resources, $from, $to) {
+                    $item->expiresAfter(new \DateInterval(self::CACHE_LIFETIME_BUSY_INTERVALS));
+
+                    return $this->getBusyIntervals($token, $resources, $from, $to);
+                },
+            ),
+            default => throw new NotAcceptableException("Invalid INSTANT_BOOK_BUSY_INTERVALS_SOURCE: {$this->busyIntervalsSource}"),
+        };
+    }
+
+    /**
+     * Derive busy intervals from the slide's calendar-output-model feed.
+     *
+     * @param string[] $resources resource ids to include in the result
+     *
+     * @return array<string, array<int, array{startTime: \DateTime, endTime: \DateTime}>>
+     *
+     * @throws NotAcceptableException
+     */
+    private function getBusyIntervalsFromFeed(?Feed $feed, array $resources, \DateTime $from, \DateTime $to): array
+    {
+        if (null === $feed) {
+            throw new NotAcceptableException('Slide feed not set.');
+        }
+
+        $feedSource = $feed->getFeedSource();
+
+        if (null === $feedSource) {
+            throw new NotAcceptableException('Feed source not set.');
+        }
+
+        $feedType = $this->feedService->getFeedType($feedSource->getFeedType());
+
+        if (FeedOutputModels::CALENDAR_OUTPUT !== $feedType->getSupportedFeedOutputType()) {
+            throw new NotAcceptableException('InstantBook (feed source) requires a calendar-output feed.');
+        }
+
+        $events = $this->feedService->getData($feed) ?? [];
+
+        $result = array_fill_keys($resources, []);
+        $fromTs = $from->getTimestamp();
+        $toTs = $to->getTimestamp();
+        $utc = new \DateTimeZone('UTC');
+
+        foreach ($events as $event) {
+            $resourceId = $event['resourceId'] ?? null;
+
+            if (!is_string($resourceId) || !array_key_exists($resourceId, $result)) {
+                continue;
+            }
+
+            $startTs = (int) ($event['startTime'] ?? 0);
+            $endTs = (int) ($event['endTime'] ?? 0);
+
+            if ($endTs <= $fromTs || $startTs >= $toTs) {
+                continue;
+            }
+
+            $result[$resourceId][] = [
+                'startTime' => (new \DateTime('@'.$startTs))->setTimezone($utc),
+                'endTime' => (new \DateTime('@'.$endTs))->setTimezone($utc),
+            ];
+        }
 
         return $result;
     }

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -450,6 +450,8 @@ class InstantBook implements InteractiveSlideInterface
      *
      * @param string[] $resources
      *
+     * @return array<string, array<int, array{startTime: \DateTime, endTime: \DateTime}>>
+     *
      * @throws \Throwable
      */
     private function fetchBusyIntervals(string $token, array $resources, \DateTime $from, \DateTime $to, Slide $slide): array

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -61,7 +61,11 @@ class InstantBook implements InteractiveSlideInterface
         private readonly CacheInterface $interactiveSlideCache,
         private readonly FeedService $feedService,
         private readonly string $busyIntervalsSource,
-    ) {}
+    ) {
+        if (!in_array($busyIntervalsSource, [self::SOURCE_GRAPH, self::SOURCE_FEED], true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid INSTANT_BOOK_BUSY_INTERVALS_SOURCE "%s"; expected "%s" or "%s".', $busyIntervalsSource, self::SOURCE_GRAPH, self::SOURCE_FEED));
+        }
+    }
 
     public function getConfigOptions(): array
     {
@@ -475,7 +479,6 @@ class InstantBook implements InteractiveSlideInterface
                     return $this->getBusyIntervals($token, $resources, $from, $to);
                 },
             ),
-            default => throw new NotAcceptableException("Invalid INSTANT_BOOK_BUSY_INTERVALS_SOURCE: {$this->busyIntervalsSource}"),
         };
     }
 

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -502,7 +502,6 @@ class InstantBook implements InteractiveSlideInterface
         $result = array_fill_keys($resources, []);
         $fromTs = $from->getTimestamp();
         $toTs = $to->getTimestamp();
-        $utc = new \DateTimeZone('UTC');
 
         foreach ($events as $event) {
             $resourceId = $event['resourceId'] ?? null;
@@ -519,8 +518,8 @@ class InstantBook implements InteractiveSlideInterface
             }
 
             $result[$resourceId][] = [
-                'startTime' => (new \DateTime('@'.$startTs))->setTimezone($utc),
-                'endTime' => (new \DateTime('@'.$endTs))->setTimezone($utc),
+                'startTime' => new \DateTime('@'.$startTs),
+                'endTime' => new \DateTime('@'.$endTs),
             ];
         }
 

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -474,15 +474,44 @@ class InstantBook implements InteractiveSlideInterface
     {
         return match ($this->busyIntervalsSource) {
             self::SOURCE_FEED => $this->getBusyIntervalsFromFeed($slide->getFeed(), $resources, $from, $to),
-            self::SOURCE_GRAPH => $this->interactiveSlideCache->get(
-                self::CACHE_KEY_BUSY_INTERVALS_PREFIX,
-                function (CacheItemInterface $item) use ($token, $resources, $from, $to) {
-                    $item->expiresAfter(new \DateInterval(self::CACHE_LIFETIME_BUSY_INTERVALS));
-
-                    return $this->getBusyIntervals($token, $resources, $from, $to);
-                },
-            ),
+            self::SOURCE_GRAPH => $this->getBusyIntervalsCached($token, $resources, $from, $to),
         };
+    }
+
+    /**
+     * Cached wrapper around getBusyIntervals().
+     *
+     * The cache key includes the resource set and the from/to window (minute precision) so that
+     * concurrent requests with different watched resources or windows do not share an entry; the
+     * previous fixed-key behaviour caused different slides to read each other's data.
+     *
+     * @param string[] $resources
+     *
+     * @return array<string, array<int, array{startTime: \DateTime, endTime: \DateTime}>>
+     *
+     * @throws InvalidArgumentException
+     */
+    private function getBusyIntervalsCached(string $token, array $resources, \DateTime $from, \DateTime $to): array
+    {
+        $sortedResources = $resources;
+        sort($sortedResources);
+
+        $cacheKey = sprintf(
+            '%s-%s-%s-%s',
+            self::CACHE_KEY_BUSY_INTERVALS_PREFIX,
+            hash('xxh128', implode('|', $sortedResources)),
+            $from->format('YmdHi'),
+            $to->format('YmdHi'),
+        );
+
+        return $this->interactiveSlideCache->get(
+            $cacheKey,
+            function (CacheItemInterface $item) use ($token, $resources, $from, $to) {
+                $item->expiresAfter(new \DateInterval(self::CACHE_LIFETIME_BUSY_INTERVALS));
+
+                return $this->getBusyIntervals($token, $resources, $from, $to);
+            },
+        );
     }
 
     /**

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -334,9 +334,11 @@ class InstantBook implements InteractiveSlideInterface
         $start = (new \DateTime())->setTimezone(new \DateTimeZone('UTC'));
         $startPlusDuration = (clone $start)->add(new \DateInterval('PT'.$durationMinutes.'M'))->setTimezone(new \DateTimeZone('UTC'));
 
-        // Pre-check the slot against live Graph state. The 409 path below is a backstop
-        // for resources whose AutomateProcessing setting actually rejects conflicts;
-        // many resources accept overlapping bookings, so we cannot rely on it alone.
+        // Pre-check the slot against live Graph state. This is required, not just an
+        // optimization: the resources used here are not configured to block conflicting
+        // bookings at the Graph API level — POSTing a conflicting booking will simply
+        // succeed rather than return 409. The 409 catch below is only a backstop for
+        // resources whose AutomateProcessing setting does reject conflicts.
         $schedules = $this->getBusyIntervals($token, [$resource], $start, $startPlusDuration);
 
         if (!$this->intervalFree($schedules[$resource] ?? [], $start, $startPlusDuration)) {

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -19,6 +19,7 @@ use App\Service\InteractiveSlideService;
 use App\Service\KeyVaultService;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -489,24 +490,24 @@ class InstantBook implements InteractiveSlideInterface
      *
      * @return array<string, array<int, array{startTime: \DateTime, endTime: \DateTime}>>
      *
-     * @throws NotAcceptableException
+     * @throws UnprocessableEntityHttpException when the slide is not configured for feed-sourced busy intervals
      */
     private function getBusyIntervalsFromFeed(?Feed $feed, array $resources, \DateTime $from, \DateTime $to): array
     {
         if (null === $feed) {
-            throw new NotAcceptableException('Slide feed not set.');
+            throw new UnprocessableEntityHttpException('InstantBook (feed source): slide feed not set.');
         }
 
         $feedSource = $feed->getFeedSource();
 
         if (null === $feedSource) {
-            throw new NotAcceptableException('Feed source not set.');
+            throw new UnprocessableEntityHttpException('InstantBook (feed source): feed source not set on slide feed.');
         }
 
         $feedType = $this->feedService->getFeedType($feedSource->getFeedType());
 
         if (FeedOutputModels::CALENDAR_OUTPUT !== $feedType->getSupportedFeedOutputType()) {
-            throw new NotAcceptableException('InstantBook (feed source) requires a calendar-output feed.');
+            throw new UnprocessableEntityHttpException('InstantBook (feed source) requires a calendar-output feed.');
         }
 
         $events = $this->feedService->getData($feed) ?? [];

--- a/src/InteractiveSlide/InstantBook.php
+++ b/src/InteractiveSlide/InstantBook.php
@@ -329,6 +329,15 @@ class InstantBook implements InteractiveSlideInterface
         $start = (new \DateTime())->setTimezone(new \DateTimeZone('UTC'));
         $startPlusDuration = (clone $start)->add(new \DateInterval('PT'.$durationMinutes.'M'))->setTimezone(new \DateTimeZone('UTC'));
 
+        // Pre-check the slot against live Graph state. The 409 path below is a backstop
+        // for resources whose AutomateProcessing setting actually rejects conflicts;
+        // many resources accept overlapping bookings, so we cannot rely on it alone.
+        $schedules = $this->getBusyIntervals($token, [$resource], $start, $startPlusDuration);
+
+        if (!$this->intervalFree($schedules[$resource] ?? [], $start, $startPlusDuration)) {
+            throw new ConflictException('Interval booked already');
+        }
+
         $requestBody = [
             'subject' => self::BOOKING_TITLE,
             'start' => [

--- a/tests/Interactive/InstantBookTest.php
+++ b/tests/Interactive/InstantBookTest.php
@@ -171,9 +171,9 @@ class InstantBookTest extends KernelTestCase
         $feedService->method('getData')->willReturn($events);
 
         return new InstantBook(
-            $this->createMock(InteractiveSlideService::class),
+            $this->container->get(InteractiveSlideService::class),
             $this->createMock(HttpClientInterface::class),
-            $this->createMock(KeyVaultService::class),
+            $this->container->get(KeyVaultService::class),
             $this->createMock(CacheInterface::class),
             $feedService,
             InstantBook::SOURCE_FEED,

--- a/tests/Interactive/InstantBookTest.php
+++ b/tests/Interactive/InstantBookTest.php
@@ -79,7 +79,7 @@ class InstantBookTest extends KernelTestCase
 
         $instantBook = $this->buildInstantBookWithFeedData($events, FeedOutputModels::CALENDAR_OUTPUT);
 
-        $feed = $this->buildFeedWithSource('App\\Feed\\CalendarApiFeedType');
+        $feed = $this->buildFeedWithSource(\App\Feed\CalendarApiFeedType::class);
 
         $result = $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [$feed, ['a@example.com', 'b@example.com'], $from, $to]);
 
@@ -97,7 +97,7 @@ class InstantBookTest extends KernelTestCase
         $to = new \DateTime('2026-01-01T11:00:00', new \DateTimeZone('UTC'));
 
         $instantBook = $this->buildInstantBookWithFeedData([], FeedOutputModels::CALENDAR_OUTPUT);
-        $feed = $this->buildFeedWithSource('App\\Feed\\CalendarApiFeedType');
+        $feed = $this->buildFeedWithSource(\App\Feed\CalendarApiFeedType::class);
 
         $result = $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [$feed, ['a@example.com'], $from, $to]);
 
@@ -107,7 +107,7 @@ class InstantBookTest extends KernelTestCase
     public function testGetBusyIntervalsFromFeedRejectsNonCalendarFeed(): void
     {
         $instantBook = $this->buildInstantBookWithFeedData([], FeedOutputModels::RSS_OUTPUT);
-        $feed = $this->buildFeedWithSource('App\\Feed\\RssFeedType');
+        $feed = $this->buildFeedWithSource(\App\Feed\RssFeedType::class);
 
         $this->expectException(NotAcceptableException::class);
 
@@ -194,7 +194,6 @@ class InstantBookTest extends KernelTestCase
     private function invokePrivate(object $target, string $method, array $args): mixed
     {
         $ref = new \ReflectionMethod($target, $method);
-        $ref->setAccessible(true);
 
         return $ref->invokeArgs($target, $args);
     }

--- a/tests/Interactive/InstantBookTest.php
+++ b/tests/Interactive/InstantBookTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Interactive;
 
 use App\Entity\Tenant\Feed;
 use App\Entity\Tenant\FeedSource;
+use App\Exceptions\ConflictException;
 use App\Feed\FeedOutputModels;
 use App\Feed\FeedTypeInterface;
 use App\InteractiveSlide\InstantBook;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class InstantBookTest extends KernelTestCase
 {
@@ -123,6 +125,44 @@ class InstantBookTest extends KernelTestCase
         $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [null, ['a@example.com'], new \DateTime(), new \DateTime('+1 hour')]);
     }
 
+    public function testAssertSlotFreeThrowsConflictWhenResourceIsBusy(): void
+    {
+        $start = new \DateTime('2030-01-01T10:00:00', new \DateTimeZone('UTC'));
+        $end = (clone $start)->modify('+30 minutes');
+        $resource = 'room-a@example.com';
+
+        $instantBook = $this->buildInstantBookWithGraphSchedule([
+            'value' => [[
+                'scheduleId' => $resource,
+                'scheduleItems' => [[
+                    'start' => ['dateTime' => '2030-01-01T10:10:00', 'timeZone' => 'UTC'],
+                    'end' => ['dateTime' => '2030-01-01T10:20:00', 'timeZone' => 'UTC'],
+                ]],
+            ]],
+        ]);
+
+        $this->expectException(ConflictException::class);
+
+        $this->invokePrivate($instantBook, 'assertSlotFree', ['fake-token', $resource, $start, $end]);
+    }
+
+    public function testAssertSlotFreePassesWhenScheduleIsEmpty(): void
+    {
+        $start = new \DateTime('2030-01-01T10:00:00', new \DateTimeZone('UTC'));
+        $end = (clone $start)->modify('+30 minutes');
+        $resource = 'room-a@example.com';
+
+        $instantBook = $this->buildInstantBookWithGraphSchedule([
+            'value' => [[
+                'scheduleId' => $resource,
+                'scheduleItems' => [],
+            ]],
+        ]);
+
+        $this->invokePrivate($instantBook, 'assertSlotFree', ['fake-token', $resource, $start, $end]);
+        $this->expectNotToPerformAssertions();
+    }
+
     private function buildInstantBookWithFeedData(array $events, string $outputType): InstantBook
     {
         $feedType = new class($outputType) implements FeedTypeInterface {
@@ -177,6 +217,24 @@ class InstantBookTest extends KernelTestCase
             $this->createMock(CacheInterface::class),
             $feedService,
             InstantBook::SOURCE_FEED,
+        );
+    }
+
+    private function buildInstantBookWithGraphSchedule(array $scheduleResponse): InstantBook
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn($scheduleResponse);
+
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('request')->willReturn($response);
+
+        return new InstantBook(
+            $this->container->get(InteractiveSlideService::class),
+            $client,
+            $this->container->get(KeyVaultService::class),
+            $this->createMock(CacheInterface::class),
+            $this->createMock(FeedService::class),
+            InstantBook::SOURCE_GRAPH,
         );
     }
 

--- a/tests/Interactive/InstantBookTest.php
+++ b/tests/Interactive/InstantBookTest.php
@@ -4,11 +4,22 @@ declare(strict_types=1);
 
 namespace App\Tests\Interactive;
 
+use App\Entity\Tenant\Feed;
+use App\Entity\Tenant\FeedSource;
+use App\Exceptions\NotAcceptableException;
+use App\Feed\FeedOutputModels;
+use App\Feed\FeedTypeInterface;
 use App\InteractiveSlide\InstantBook;
+use App\Service\FeedService;
+use App\Service\InteractiveSlideService;
+use App\Service\KeyVaultService;
 use Doctrine\ORM\EntityManager;
 use Hautelook\AliceBundle\PhpUnit\BaseDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class InstantBookTest extends KernelTestCase
 {
@@ -48,5 +59,141 @@ class InstantBookTest extends KernelTestCase
 
         $intervalFree = $service->intervalFree($schedules, new \DateTime('+15 minutes'), new \DateTime('+45 minutes'));
         $this->assertFalse($intervalFree);
+    }
+
+    public function testGetBusyIntervalsFromFeedFiltersByResourceAndWindow(): void
+    {
+        $from = new \DateTime('2026-01-01T10:00:00', new \DateTimeZone('UTC'));
+        $to = new \DateTime('2026-01-01T11:00:00', new \DateTimeZone('UTC'));
+
+        $events = [
+            // In-window event for resource A.
+            ['resourceId' => 'a@example.com', 'startTime' => $from->getTimestamp() + 600,  'endTime' => $from->getTimestamp() + 1800],
+            // In-window event for resource B.
+            ['resourceId' => 'b@example.com', 'startTime' => $from->getTimestamp() + 1200, 'endTime' => $from->getTimestamp() + 2400],
+            // Out-of-window event (entirely before from).
+            ['resourceId' => 'a@example.com', 'startTime' => $from->getTimestamp() - 7200, 'endTime' => $from->getTimestamp() - 3600],
+            // Event for an unwatched resource.
+            ['resourceId' => 'c@example.com', 'startTime' => $from->getTimestamp() + 600,  'endTime' => $from->getTimestamp() + 1800],
+        ];
+
+        $instantBook = $this->buildInstantBookWithFeedData($events, FeedOutputModels::CALENDAR_OUTPUT);
+
+        $feed = $this->buildFeedWithSource('App\\Feed\\CalendarApiFeedType');
+
+        $result = $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [$feed, ['a@example.com', 'b@example.com'], $from, $to]);
+
+        $this->assertSame(['a@example.com', 'b@example.com'], array_keys($result));
+        $this->assertCount(1, $result['a@example.com']);
+        $this->assertCount(1, $result['b@example.com']);
+        $this->assertInstanceOf(\DateTime::class, $result['a@example.com'][0]['startTime']);
+        $this->assertInstanceOf(\DateTime::class, $result['a@example.com'][0]['endTime']);
+        $this->assertSame($from->getTimestamp() + 600, $result['a@example.com'][0]['startTime']->getTimestamp());
+    }
+
+    public function testGetBusyIntervalsFromFeedReturnsEmptyForResourcesWithoutEvents(): void
+    {
+        $from = new \DateTime('2026-01-01T10:00:00', new \DateTimeZone('UTC'));
+        $to = new \DateTime('2026-01-01T11:00:00', new \DateTimeZone('UTC'));
+
+        $instantBook = $this->buildInstantBookWithFeedData([], FeedOutputModels::CALENDAR_OUTPUT);
+        $feed = $this->buildFeedWithSource('App\\Feed\\CalendarApiFeedType');
+
+        $result = $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [$feed, ['a@example.com'], $from, $to]);
+
+        $this->assertSame(['a@example.com' => []], $result);
+    }
+
+    public function testGetBusyIntervalsFromFeedRejectsNonCalendarFeed(): void
+    {
+        $instantBook = $this->buildInstantBookWithFeedData([], FeedOutputModels::RSS_OUTPUT);
+        $feed = $this->buildFeedWithSource('App\\Feed\\RssFeedType');
+
+        $this->expectException(NotAcceptableException::class);
+
+        $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [$feed, ['a@example.com'], new \DateTime(), new \DateTime('+1 hour')]);
+    }
+
+    public function testGetBusyIntervalsFromFeedRejectsNullFeed(): void
+    {
+        $instantBook = $this->buildInstantBookWithFeedData([], FeedOutputModels::CALENDAR_OUTPUT);
+
+        $this->expectException(NotAcceptableException::class);
+
+        $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [null, ['a@example.com'], new \DateTime(), new \DateTime('+1 hour')]);
+    }
+
+    private function buildInstantBookWithFeedData(array $events, string $outputType): InstantBook
+    {
+        $feedType = new class($outputType) implements FeedTypeInterface {
+            public function __construct(private readonly string $outputType) {}
+
+            public function getData(Feed $feed): array
+            {
+                return [];
+            }
+
+            public function getAdminFormOptions(FeedSource $feedSource): array
+            {
+                return [];
+            }
+
+            public function getConfigOptions(Request $request, FeedSource $feedSource, string $name): ?array
+            {
+                return null;
+            }
+
+            public function getRequiredSecrets(): array
+            {
+                return [];
+            }
+
+            public function getRequiredConfiguration(): array
+            {
+                return [];
+            }
+
+            public function getSupportedFeedOutputType(): string
+            {
+                return $this->outputType;
+            }
+
+            public function getSchema(): array
+            {
+                return [];
+            }
+        };
+
+        $feedService = $this->createMock(FeedService::class);
+        $feedService->method('getFeedType')->willReturn($feedType);
+        $feedService->method('getData')->willReturn($events);
+
+        return new InstantBook(
+            $this->createMock(InteractiveSlideService::class),
+            $this->createMock(HttpClientInterface::class),
+            $this->createMock(KeyVaultService::class),
+            $this->createMock(CacheInterface::class),
+            $feedService,
+            InstantBook::SOURCE_FEED,
+        );
+    }
+
+    private function buildFeedWithSource(string $feedTypeClassName): Feed
+    {
+        $feedSource = new FeedSource();
+        $feedSource->setFeedType($feedTypeClassName);
+
+        $feed = new Feed();
+        $feed->setFeedSource($feedSource);
+
+        return $feed;
+    }
+
+    private function invokePrivate(object $target, string $method, array $args): mixed
+    {
+        $ref = new \ReflectionMethod($target, $method);
+        $ref->setAccessible(true);
+
+        return $ref->invokeArgs($target, $args);
     }
 }

--- a/tests/Interactive/InstantBookTest.php
+++ b/tests/Interactive/InstantBookTest.php
@@ -126,7 +126,9 @@ class InstantBookTest extends KernelTestCase
     private function buildInstantBookWithFeedData(array $events, string $outputType): InstantBook
     {
         $feedType = new class($outputType) implements FeedTypeInterface {
-            public function __construct(private readonly string $outputType) {}
+            public function __construct(
+                private readonly string $outputType,
+            ) {}
 
             public function getData(Feed $feed): array
             {

--- a/tests/Interactive/InstantBookTest.php
+++ b/tests/Interactive/InstantBookTest.php
@@ -6,7 +6,6 @@ namespace App\Tests\Interactive;
 
 use App\Entity\Tenant\Feed;
 use App\Entity\Tenant\FeedSource;
-use App\Exceptions\NotAcceptableException;
 use App\Feed\FeedOutputModels;
 use App\Feed\FeedTypeInterface;
 use App\InteractiveSlide\InstantBook;
@@ -18,6 +17,7 @@ use Hautelook\AliceBundle\PhpUnit\BaseDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -109,7 +109,7 @@ class InstantBookTest extends KernelTestCase
         $instantBook = $this->buildInstantBookWithFeedData([], FeedOutputModels::RSS_OUTPUT);
         $feed = $this->buildFeedWithSource(\App\Feed\RssFeedType::class);
 
-        $this->expectException(NotAcceptableException::class);
+        $this->expectException(UnprocessableEntityHttpException::class);
 
         $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [$feed, ['a@example.com'], new \DateTime(), new \DateTime('+1 hour')]);
     }
@@ -118,7 +118,7 @@ class InstantBookTest extends KernelTestCase
     {
         $instantBook = $this->buildInstantBookWithFeedData([], FeedOutputModels::CALENDAR_OUTPUT);
 
-        $this->expectException(NotAcceptableException::class);
+        $this->expectException(UnprocessableEntityHttpException::class);
 
         $this->invokePrivate($instantBook, 'getBusyIntervalsFromFeed', [null, ['a@example.com'], new \DateTime(), new \DateTime('+1 hour')]);
     }


### PR DESCRIPTION
NB! Builds on https://github.com/os2display/display-api-service/pull/433

#### Link to issue

https://github.com/os2display/display-api-service/issues/436

#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/7208

#### Description

- Added strategy to "Instant Book" where busy intervals are retrieved from calendar feed.
- Fixed instant booking template error handling.
- Fixed bugs when fetching intervals.
- Fixed calendar test issue following change to 10 min default update interval.

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
