### PR TITLE
fix: rewrite APP_ENV to prod in baked-in .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fixed Calendar and Colibo feed configuration urls and added [] result when no locationEndpoint is set.
-- Fixed baked-in `.env` shipping `APP_ENV=dev` in the API image; rewritten to `prod` at build time so direct reads of `.env` don't try to bootstrap a dev environment that the prod-only dependencies can't satisfy.
+- Fixed baked-in `.env` shipping `APP_ENV=dev` in the API image; rewritten to `prod` at build time so
+  direct reads don't try to bootstrap a dev environment the prod-only dependencies can't satisfy.
 
 ## [3.0.0-rc2] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fixed Calendar and Colibo feed configuration urls and added [] result when no locationEndpoint is set.
+- Fixed baked-in `.env` shipping `APP_ENV=dev` in the API image; rewritten to `prod` at build time so direct reads of `.env` don't try to bootstrap a dev environment that the prod-only dependencies can't satisfy.
 
 ## [3.0.0-rc2] - 2026-05-05
 

--- a/infrastructure/display-api-service/Dockerfile
+++ b/infrastructure/display-api-service/Dockerfile
@@ -63,6 +63,12 @@ RUN APP_ENV=prod composer install --no-dev -o --classmap-authoritative --no-scri
 # rest of public/media/ — see the file for the preserved entries.
 COPY --chown=deploy:deploy --from=repository-root ./ ./
 
+# The committed .env defaults APP_ENV to dev for local development. The
+# image only ships prod dependencies (composer install --no-dev), so any
+# tooling that reads .env directly without our docker-entrypoint.sh
+# would bootstrap a dev environment that can't resolve its services.
+RUN sed -i 's/^APP_ENV=dev$/APP_ENV=prod/' .env
+
 # Vite manifest must be in place before the second composer install
 # triggers cache:clear, otherwise the vite bundle can't generate its
 # cache config files.


### PR DESCRIPTION
## Summary
The committed `.env` defaults `APP_ENV=dev` for local development. The API image only ships prod dependencies (`composer install --no-dev`), so any tooling that reads `.env` directly without going through `docker-entrypoint.sh` (which runs `composer dump-env prod`) would try to bootstrap a dev environment that can't resolve its services.

## Files Changed
* `infrastructure/display-api-service/Dockerfile` — added a `RUN sed` step in the `api_app_builder` stage that rewrites `APP_ENV=dev` → `APP_ENV=prod` in the in-image `.env`, right after the full source `COPY`. The source `.env` is untouched, so local dev keeps defaulting to `dev`.
* `CHANGELOG.md` — entry under `[Unreleased]`.

## Test Plan
* Build the image: `docker build -f infrastructure/display-api-service/Dockerfile .`
* Inspect the baked-in `.env`: `docker run --rm --entrypoint sh <image> -c 'grep ^APP_ENV= .env'` — expect `APP_ENV=prod`.
* Boot the container normally and confirm the entrypoint still runs `composer dump-env prod` and `cache:warmup` without errors.
* Confirm local dev compose stack still picks up `APP_ENV=dev` from the source `.env` (the file on disk is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)