### PR TITLE
chore: align image labels with OCI image spec

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -98,6 +98,11 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/os2display/display-api-service-nginx
+          # Override the source-repo defaults; without this the Nginx image
+          # would publish title/description copied from display-api-service.
+          labels: |
+            org.opencontainers.image.title=display-api-service-nginx
+            org.opencontainers.image.description=Nginx reverse proxy fronting the OS2Display API image
           tags: |
             # develop branch → 'develop'
             type=ref,event=branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - Fixed Calendar and Colibo feed configuration urls and added [] result when no locationEndpoint is set.
 - Fixed baked-in `.env` shipping `APP_ENV=dev` in the API image; rewritten to `prod` at build time so
   direct reads don't try to bootstrap a dev environment the prod-only dependencies can't satisfy.
+- Aligned API and Nginx image labels with the OCI image spec: dropped deprecated `LABEL maintainer`,
+  added `org.opencontainers.image.{authors,vendor,documentation,base.name}`, and fixed the Nginx image's
+  `title`/`description` so it stops inheriting the source-repo defaults.
 
 ## [3.0.0-rc2] - 2026-05-05
 

--- a/infrastructure/display-api-service/Dockerfile
+++ b/infrastructure/display-api-service/Dockerfile
@@ -2,7 +2,6 @@
 # Assets build
 ################################
 FROM node:24-alpine AS assets_builder
-LABEL maintainer="ITK Dev <itkdev@ba.aarhus.dk>"
 
 ARG APP_VERSION="develop"
 
@@ -33,7 +32,6 @@ RUN npm run build
 # TODO: pin to a specific `alpine-1.4.x` tag (or a digest) once we
 # settle on a baseline. Same caveat applies to the final stage below.
 FROM itkdev/php8.4-fpm:alpine AS api_app_builder
-LABEL maintainer="ITK Dev <itkdev@ba.aarhus.dk>"
 
 ARG APP_VERSION="develop"
 ARG APP_RELEASE_TIMESTAMP=0
@@ -90,7 +88,15 @@ RUN printf '{"releaseTimestamp": %s, "releaseTime": "%s", "releaseVersion": "%s"
 # PHP-FPM (API) production image
 ################################
 FROM itkdev/php8.4-fpm:alpine
-LABEL maintainer="ITK Dev <itkdev@ba.aarhus.dk>"
+
+# OCI image annotations. `title`, `description`, `url`, `source`, `version`,
+# `created`, `revision` and `licenses` are injected at build time by the
+# docker/metadata-action step in .github/workflows/build-images.yml; the
+# four below are not emitted by that action and have to live here.
+LABEL org.opencontainers.image.authors="ITK Dev <itkdev@ba.aarhus.dk>" \
+      org.opencontainers.image.vendor="OS2Display" \
+      org.opencontainers.image.documentation="https://github.com/os2display/display-api-service#readme" \
+      org.opencontainers.image.base.name="itkdev/php8.4-fpm:alpine"
 
 ENV APP_ENV=prod \
     PHP_OPCACHE_ENABLED=1 \

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -10,7 +10,16 @@ FROM ${APP_IMAGE}:${APP_VERSION} AS app
 
 ######## Nginx production image ########
 FROM nginxinc/nginx-unprivileged:alpine
-LABEL maintainer="ITK Dev <itkdev@ba.aarhus.dk>"
+
+# OCI image annotations. `title`, `description`, `url`, `source`, `version`,
+# `created`, `revision` and `licenses` are injected at build time by the
+# docker/metadata-action step in .github/workflows/build-images.yml — the
+# nginx-specific `title`/`description` overrides live in that workflow
+# because metadata-action's --label flags win over Dockerfile LABELs.
+LABEL org.opencontainers.image.authors="ITK Dev <itkdev@ba.aarhus.dk>" \
+      org.opencontainers.image.vendor="OS2Display" \
+      org.opencontainers.image.documentation="https://github.com/os2display/display-api-service#readme" \
+      org.opencontainers.image.base.name="nginxinc/nginx-unprivileged:alpine"
 
 ARG UID=101
 


### PR DESCRIPTION
## Summary
Brings the API and Nginx Dockerfiles into line with the OCI image spec, drops the deprecated `LABEL maintainer`, and fixes the Nginx image's mislabeled title/description (which was inheriting `display-api-service` from the source repo).

`docker/metadata-action@v6` already injects 8 of the 14 pre-defined `org.opencontainers.image.*` keys at build time (`title`, `description`, `url`, `source`, `version`, `created`, `revision`, `licenses`). This PR adds the four it doesn't emit (`authors`, `vendor`, `documentation`, `base.name`) directly in the Dockerfiles, and overrides the Nginx-specific `title`/`description` in the workflow because `metadata-action`'s `--label` flags win over Dockerfile `LABEL`s.

## Files Changed
* `infrastructure/display-api-service/Dockerfile` — drop `LABEL maintainer` from `assets_builder` and `api_app_builder` (builder-stage labels never reach the published image); replace the final stage's `LABEL maintainer` with a consolidated OCI block.
* `infrastructure/nginx/Dockerfile` — same treatment, `base.name=nginxinc/nginx-unprivileged:alpine`.
* `.github/workflows/build-images.yml` — add a `labels:` input to the Nginx `metadata-action` step so the published Nginx image gets `title=display-api-service-nginx` instead of the source-repo default.
* `CHANGELOG.md` — entry under `[Unreleased]`.

## Out of scope (intentional)
* `org.opencontainers.image.base.digest` — meaningless until base images are pinned by digest (TODO already present in the API Dockerfile). Couple with that change.
* `composer.json` license vs. `LICENSE` file mismatch (`proprietary` vs. MPL-2.0). `metadata-action` reads from GitHub so the published label is correct, but the source files disagree — separate triage.

## Test Plan
* Build locally: `docker buildx build -f infrastructure/display-api-service/Dockerfile --build-context repository-root=. -t oci-check ./infrastructure/display-api-service/`
* `docker inspect oci-check --format '{{json .Config.Labels}}' | jq` — expect `org.opencontainers.image.authors`, `vendor`, `documentation`, `base.name` present; no `maintainer`.
* Same for the nginx image; expect `base.name=nginxinc/nginx-unprivileged:alpine`.
* After CI push, pull `ghcr.io/os2display/display-api-service-nginx:<branch-tag>` and confirm `title=display-api-service-nginx` (not `display-api-service`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)