### PR TITLE
feat: support MariaDB 10 and 11; default local to 11 LTS, matrix CI

### DIFF
--- a/.env
+++ b/.env
@@ -30,16 +30,16 @@ TRUSTED_PROXIES=127.0.0.1,REMOTE_ADDR
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###
+# Doctrine `serverVersion` for dialect selection — must match the running
+# MariaDB. Default tracks the docker-compose default (mariadb:11.4);
+# override MARIADB_VERSION (and the matching MARIADB_IMAGE in compose) to
+# test against 10.11.
+MARIADB_VERSION=11.4.4-MariaDB
 # Database connection string for MariaDB/MySQL.
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-# Doctrine's `serverVersion` controls the dialect, so it must match the
-# MariaDB you actually run. Default tracks the docker-compose default
-# (mariadb:11.4); override MARIADB_VERSION (and the matching MARIADB_IMAGE
-# in compose) to test against 10.11.
-MARIADB_VERSION=11.4.4-MariaDB
 DATABASE_URL="mysql://db:db@mariadb:3306/db?serverVersion=${MARIADB_VERSION}"
 #DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
 ###< doctrine/doctrine-bundle ###

--- a/.env
+++ b/.env
@@ -35,7 +35,12 @@ TRUSTED_PROXIES=127.0.0.1,REMOTE_ADDR
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-DATABASE_URL="mysql://db:db@mariadb:3306/db?serverVersion=10.11.5-MariaDB"
+# Doctrine's `serverVersion` controls the dialect, so it must match the
+# MariaDB you actually run. Default tracks the docker-compose default
+# (mariadb:11.4); override MARIADB_VERSION (and the matching MARIADB_IMAGE
+# in compose) to test against 10.11.
+MARIADB_VERSION=11.4.4-MariaDB
+DATABASE_URL="mysql://db:db@mariadb:3306/db?serverVersion=${MARIADB_VERSION}"
 #DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 

--- a/.env.test
+++ b/.env.test
@@ -5,7 +5,7 @@ SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 
-DATABASE_URL="mysql://root:password@mariadb:3306/db_test?serverVersion=mariadb-10.5.13"
+DATABASE_URL="mysql://root:password@mariadb:3306/db_test?serverVersion=${MARIADB_VERSION}"
 
 ###> lexik/jwt-authentication-bundle ###
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem

--- a/.github/workflows/doctrine.yaml
+++ b/.github/workflows/doctrine.yaml
@@ -19,7 +19,20 @@ env:
 jobs:
   validate-doctrine-shema:
     runs-on: ubuntu-latest
-    name: Validate Schema
+    strategy:
+      # Don't cancel the 11.x leg if 10.x fails (or vice versa); we want to
+      # see version-specific failures rather than mask one with the other.
+      fail-fast: false
+      matrix:
+        mariadb:
+          - image: mariadb:10.11
+            version: 10.11.13-MariaDB
+          - image: mariadb:11.4
+            version: 11.4.4-MariaDB
+    name: Validate Schema (${{ matrix.mariadb.image }})
+    env:
+      MARIADB_IMAGE: ${{ matrix.mariadb.image }}
+      MARIADB_VERSION: ${{ matrix.mariadb.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,7 +51,7 @@ jobs:
         run: docker compose run --rm -e APP_ENV=prod phpfpm composer install --no-dev -o
 
       - name: Run Doctrine Migrations
-        run: docker compose run --rm -e APP_ENV=prod phpfpm bin/console doctrine:migrations:migrate --no-interaction
+        run: docker compose run --rm -e APP_ENV=prod -e MARIADB_VERSION phpfpm bin/console doctrine:migrations:migrate --no-interaction
 
       - name: Validate Doctrine schema
-        run: docker compose run --rm -e APP_ENV=prod phpfpm bin/console doctrine:schema:validate
+        run: docker compose run --rm -e APP_ENV=prod -e MARIADB_VERSION phpfpm bin/console doctrine:schema:validate

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -19,7 +19,23 @@ env:
 jobs:
   phpunit:
     runs-on: ubuntu-latest
-    name: PHP Unit tests
+    strategy:
+      # Don't cancel the 11.x leg if 10.x fails (or vice versa); we want to
+      # see version-specific failures rather than mask one with the other.
+      fail-fast: false
+      matrix:
+        mariadb:
+          - image: mariadb:10.11
+            version: 10.11.13-MariaDB
+          - image: mariadb:11.4
+            version: 11.4.4-MariaDB
+    name: PHP Unit tests (${{ matrix.mariadb.image }})
+    env:
+      # Picked up by docker-compose.yml's `image: ${MARIADB_IMAGE:-…}`.
+      MARIADB_IMAGE: ${{ matrix.mariadb.image }}
+      # Forwarded into phpfpm via `-e MARIADB_VERSION` below; .env then
+      # interpolates it into Doctrine's `serverVersion` URL parameter.
+      MARIADB_VERSION: ${{ matrix.mariadb.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,7 +54,7 @@ jobs:
         run: docker compose run --rm phpfpm composer install
 
       - name: PHP Unit - Test setup
-        run: docker compose run --rm phpfpm composer run test-setup
+        run: docker compose run --rm -e MARIADB_VERSION phpfpm composer run test-setup
 
       - name: PHP Unit - Run tests
-        run: docker compose run --rm phpfpm composer run test
+        run: docker compose run --rm -e MARIADB_VERSION phpfpm composer run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
   `SESSION_HANDLER_DSN=` empty to fall back to PHP's native file handler. Removes the per-session
   `flock` that serialised parallel session-touching requests and lets sessions survive container
   restarts; multi-pod deployments now share session state without sticky routing.
+- Switched local dev MariaDB to upstream `mariadb:11.4` LTS (was `itkdev/mariadb:latest`); both 10.11
+  and 11.4 LTS are now exercised by a CI matrix in the PHPUnit and Doctrine schema-validate workflows.
+  `MARIADB_IMAGE` and `MARIADB_VERSION` env vars override the compose image and Doctrine
+  `serverVersion`. Drops the previously-commented `ENCRYPT=1` toggle inherited from the itkdev wrapper.
 
 ## [3.0.0-rc2] - 2026-05-05
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ The fixtures have an editor user: <editor@example.com> with the password: "apass
 
 The fixtures have the image-text template, and two screen layouts: "full screen" and "two boxes".
 
+### Database (MariaDB)
+
+Local dev defaults to `mariadb:11.4` (LTS until May 2029). CI also exercises `mariadb:10.11` (LTS until
+Feb 2028) via a matrix in `phpunit.yaml` and `doctrine.yaml`. Two env vars control the version:
+
+- `MARIADB_IMAGE` — the docker image used by the `mariadb` compose service.
+- `MARIADB_VERSION` — the Doctrine `serverVersion` interpolated into `DATABASE_URL` in `.env` /
+  `.env.test`. Must match the running server, or Doctrine will emit dialect-incompatible SQL.
+
+To run the local stack against 10.11:
+
+```shell
+docker compose down -v
+MARIADB_IMAGE=mariadb:10.11 MARIADB_VERSION=10.11.13-MariaDB docker compose up -d
+```
+
 ## Production setup
 
 A JWT Auth keypair should be generated. See [JWT Auth](#jwt-auth).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,12 @@ networks:
 
 services:
   mariadb:
-    image: itkdev/mariadb:latest
+    # 11.4 is MariaDB's LTS series (supported until May 2029); 10.11 (LTS
+    # until Feb 2028) is also tested in CI via the matrix in
+    # .github/workflows/{phpunit,doctrine}.yaml. Override MARIADB_IMAGE
+    # locally to test against 10.11; remember to set MARIADB_VERSION to
+    # match (Doctrine uses it for dialect detection — see .env).
+    image: ${MARIADB_IMAGE:-mariadb:11.4}
     networks:
       - app
     ports:
@@ -24,7 +29,6 @@ services:
       - MYSQL_USER=db
       - MYSQL_PASSWORD=db
       - MYSQL_DATABASE=db
-      #- ENCRYPT=1 # Uncomment to enable database encryption.
 
   phpfpm:
     image: itkdev/php8.4-fpm:latest


### PR DESCRIPTION
## Summary
Pins local dev to MariaDB 11.4 LTS (was the moving `itkdev/mariadb:latest` alias, whose underlying version was undeclared) and adds a 2-leg CI matrix so PHPUnit and the Doctrine schema-validate workflow each run on `mariadb:10.11` LTS and `mariadb:11.4` LTS.

Also fixes an existing inconsistency: `.env` claimed `serverVersion=10.11.5-MariaDB` while `.env.test` claimed the EOL `mariadb-10.5.13`. Both now interpolate `${MARIADB_VERSION}` from a single source of truth in `.env` (default `11.4.4-MariaDB`), and CI overrides per matrix leg.

## Files Changed
* `docker-compose.yml` — `image: ${MARIADB_IMAGE:-mariadb:11.4}`. Drops the unused commented-out `ENCRYPT=1` env (itkdev wrapper-only feature).
* `.env` — adds `MARIADB_VERSION=11.4.4-MariaDB`; `DATABASE_URL` interpolates it.
* `.env.test` — same interpolation; reuses `MARIADB_VERSION` from `.env` (or CI override).
* `.github/workflows/phpunit.yaml` — `strategy.matrix` over `mariadb:10.11` + `mariadb:11.4`; `fail-fast: false`. Forwards `MARIADB_VERSION` into the phpfpm container via `docker compose run -e MARIADB_VERSION`.
* `.github/workflows/doctrine.yaml` — same matrix shape for the migrate-and-validate job.
* `README.md` — adds a `### Database (MariaDB)` subsection under Development setup documenting the `MARIADB_IMAGE` / `MARIADB_VERSION` overrides with a copy-paste example for testing 10.11 locally.
* `CHANGELOG.md` — `[Unreleased]` entry.

## Why upstream `mariadb:` and not `itkdev/mariadb`?
`itkdev/mariadb` on Docker Hub publishes only `latest` and `1.x.y` wrapper tags (no major-version tags), so a clean matrix isn't expressible against it. The wrapper's only material extra is an opt-in `ENCRYPT=1` that this repo's compose has commented out — `MYSQL_*` env vars and `healthcheck.sh` work the same on upstream.

## Local verification (already run on 11.4)
Boot + migrate + full PHPUnit suite + schema-validate, all green against `mariadb:11.4.10`:
- 143 tests / 607 assertions pass
- 26 migrations apply cleanly
- `doctrine:schema:validate` reports schema in sync

10.11 leg verified by CI matrix once this PR runs.

## Test Plan
* Local 10 LTS override:
  ```sh
  docker compose down -v
  MARIADB_IMAGE=mariadb:10.11 MARIADB_VERSION=10.11.13-MariaDB docker compose up -d mariadb
  docker compose exec mariadb mariadb --version    # expect 10.11.x
  MARIADB_VERSION=10.11.13-MariaDB docker compose run --rm phpfpm composer run test-setup
  MARIADB_VERSION=10.11.13-MariaDB docker compose run --rm phpfpm composer run test
  ```
* CI: confirm the Checks tab shows two `PHP Unit tests` jobs and two `Validate Schema` jobs (one per matrix leg), all green. With `fail-fast: false`, a 10-only or 11-only failure stays visible rather than being masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)