### PR TITLE
feat: move Symfony sessions to Redis, env-configurable

### DIFF
--- a/.env
+++ b/.env
@@ -72,6 +72,13 @@ JWT_SCREEN_REFRESH_TOKEN_TTL=2592000
 REDIS_CACHE_PREFIX=DisplayApiService
 # Connection string for Redis cache server.
 REDIS_CACHE_DSN=redis://redis:6379/0
+# Session storage backend, consumed by framework.session.handler_id.
+# A `redis://...` DSN makes Symfony auto-build a RedisSessionHandler (with
+# its own `sf_s` key prefix, so cache and session keys don't collide on
+# the same DB). Empty value = PHP's native file handler; pick that for
+# single-pod deployments that don't care about flock-induced tail latency
+# or container-restart session survival.
+SESSION_HANDLER_DSN=${REDIS_CACHE_DSN}
 ###< redis ###
 
 ###> Http Client ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,12 @@ All notable changes to this project will be documented in this file.
 - Aligned API and Nginx image labels with the OCI image spec: dropped deprecated `LABEL maintainer`,
   added `org.opencontainers.image.{authors,vendor,documentation,base.name}`, and fixed the Nginx image's
   `title`/`description` so it stops inheriting the source-repo defaults.
-<<<<<<< HEAD
 - Bumped the local dev Redis image from `redis:6` to `redis:8`. Production deployments are unaffected
   (they bring their own Redis); Symfony 6.4's cache adapter and the bundled phpredis 6.3 work as-is.
-=======
 - Switched Symfony session storage to Redis (default `SESSION_HANDLER_DSN=${REDIS_CACHE_DSN}`); set
   `SESSION_HANDLER_DSN=` empty to fall back to PHP's native file handler. Removes the per-session
   `flock` that serialised parallel session-touching requests and lets sessions survive container
   restarts; multi-pod deployments now share session state without sticky routing.
->>>>>>> e4abf911 (feat: move Symfony sessions to Redis, env-configurable)
 
 ## [3.0.0-rc2] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,15 @@ All notable changes to this project will be documented in this file.
 - Aligned API and Nginx image labels with the OCI image spec: dropped deprecated `LABEL maintainer`,
   added `org.opencontainers.image.{authors,vendor,documentation,base.name}`, and fixed the Nginx image's
   `title`/`description` so it stops inheriting the source-repo defaults.
+<<<<<<< HEAD
 - Bumped the local dev Redis image from `redis:6` to `redis:8`. Production deployments are unaffected
   (they bring their own Redis); Symfony 6.4's cache adapter and the bundled phpredis 6.3 work as-is.
+=======
+- Switched Symfony session storage to Redis (default `SESSION_HANDLER_DSN=${REDIS_CACHE_DSN}`); set
+  `SESSION_HANDLER_DSN=` empty to fall back to PHP's native file handler. Removes the per-session
+  `flock` that serialised parallel session-touching requests and lets sessions survive container
+  restarts; multi-pod deployments now share session state without sticky routing.
+>>>>>>> e4abf911 (feat: move Symfony sessions to Redis, env-configurable)
 
 ## [3.0.0-rc2] - 2026-05-05
 

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -9,7 +9,13 @@ framework:
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:
-        handler_id: null
+        # Empty falls back to PHP's native file handler; a `redis://...` DSN
+        # makes Symfony auto-build a RedisSessionHandler. See SESSION_HANDLER_DSN
+        # in .env. Redis-backed sessions remove the per-session flock that
+        # serialises parallel requests on the file handler and survive
+        # container restarts; local dev gets the same behaviour because the
+        # default DSN points at the compose Redis.
+        handler_id: '%env(SESSION_HANDLER_DSN)%'
         cookie_secure: auto
         cookie_samesite: lax
         storage_factory_id: session.storage.factory.native
@@ -33,4 +39,8 @@ when@test:
     framework:
         test: true
         session:
+            # MockFileSessionStorage keeps tests off Redis; force handler_id
+            # back to native so the Redis handler service isn't compiled
+            # against an env that may not point at a reachable Redis.
+            handler_id: null
             storage_factory_id: session.storage.factory.mock_file


### PR DESCRIPTION
## Summary
`framework.session.handler_id` now reads from a new `SESSION_HANDLER_DSN` env var, which defaults to the existing `REDIS_CACHE_DSN`. Symfony's built-in `SessionHandlerFactory` auto-creates a `RedisSessionHandler` from the `redis://...` DSN — no service wiring or new dependencies. Operators can set `SESSION_HANDLER_DSN=` empty to fall back to PHP's native file handler.

## Why
- Removes the per-session `flock` that serialises parallel session-touching requests on the file handler (visible as inconsistent tail latency when the React admin fires concurrent fetches).
- Sessions survive container restarts without mounting `/tmp` as a volume.
- Multi-pod deployments share session state without sticky routing — the OIDC handshake works regardless of which pod handles the callback.

## Files Changed
* `config/packages/framework.yaml` — `handler_id: '%env(SESSION_HANDLER_DSN)%'` in the global config; `when@test` forces it back to `null` since `MockFileSessionStorage` bypasses handlers and we don't want the test container compiling a Redis handler against an env that may not point at a reachable Redis.
* `.env` — adds `SESSION_HANDLER_DSN=${REDIS_CACHE_DSN}` with comment explaining the override path.
* `CHANGELOG.md` — `[Unreleased]` entry.

## Key isolation
The auto-built `RedisSessionHandler` prefixes keys with `sf_s`. Cache uses Symfony's own `cache.adapter.redis` prefix machinery driven by `REDIS_CACHE_PREFIX=DisplayApiService`. So sharing one Redis DB between cache and sessions is safe — keys don't collide. Operators wanting full DB separation can override `SESSION_HANDLER_DSN=redis://redis:6379/1` (or whatever DB).

## Local verification (already run)
* `docker compose run phpfpm bin/console debug:container session.handler` reports the handler is built via `SessionHandlerFactory::createHandler` — Symfony's auto-build path for DSNs.
* HTTP request to `/v2/authentication/oidc/urls` (the OIDC URL endpoint, which writes the session for state tracking) returns 200 and sets a `PHPSESSID` cookie. Inspecting Redis post-request: exactly one key, `sf_s<session-id>`, matching the cookie.
* Full PHPUnit suite passes (143 tests, 607 assertions). Redis `DBSIZE=0` after the suite, confirming the `when@test` override keeps tests off Redis.

## Test Plan
* Pull the branch, `docker compose down -v && docker compose up -d`.
* `curl -s -c /tmp/c.txt -o /dev/null -w '%{http_code}\n' http://nginx:8080/v2/authentication/oidc/urls?providerKey=internal` → expect `200`.
* `docker compose exec redis redis-cli DBSIZE` → expect `1` (one new `sf_s<id>` key).
* Override path: `SESSION_HANDLER_DSN= docker compose run --rm phpfpm bin/console debug:config framework session` → handler_id should resolve to empty/null and Symfony falls back to native file handler.
* `docker compose run --rm phpfpm composer run test` → expect 143/143 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)