### PR TITLE
fix: align composer.json license with LICENSE (MPL-2.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,13 @@
 {
     "name": "os2display/display-api-service",
     "description": "Api backend for OS2display",
-    "license": "proprietary",
+    "license": "MPL-2.0",
     "type": "project",
+    "homepage": "https://github.com/os2display/display-api-service",
+    "support": {
+        "issues": "https://github.com/os2display/display-api-service/issues",
+        "source": "https://github.com/os2display/display-api-service"
+    },
     "require": {
         "php": ">=8.4",
         "ext-ctype": "*",


### PR DESCRIPTION
## Summary

- Sets `composer.json` `license` to `MPL-2.0`, matching the `LICENSE` file shipped at the repo root. Was incorrectly `proprietary` — wrong for a public open-source project and contradicting the bundled license terms.
- Adds two related project-meta fields that the previous file was missing: `homepage` (canonical repo URL) and `support.issues` / `support.source` (issue tracker + source URL). Used by `composer support`, GitHub's dependency graph, SBOM generators, and Packagist.

## Other meta — left to your call

These are also missing but I held off because they need input rather than a clear-cut fix. Worth a follow-up commit on this branch (or a separate PR) if you'd like:

- **`authors`** — array of `{ name, email }` for credited contributors. ITK Dev / OS2Display org? Specific maintainers?
- **`keywords`** — searchable tags. Optional for `type: project` projects; useful if this ever ends up on Packagist.
- **`description`** — currently \"Api backend for OS2display\". The repo now houses the full project (admin + client + templates per `UPGRADE.md`), so something like \"OS2Display\" or \"OS2Display digital signage platform\" would be more accurate. I left it alone to keep the PR scope minimal.

Happy to push any of these once you decide.

## Test plan

- [x] `composer validate --strict` → green
- [x] `composer normalize --dry-run` → already normalised

🤖 Generated with [Claude Code](https://claude.com/claude-code)