### PR TITLE
feat: prep db identifiers for cross-platform (Postgres) portability

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,6 +104,70 @@ jobs:
       - name: Validate Doctrine schema
         run: APP_ENV=prod php bin/console doctrine:schema:validate
 
+  validate-doctrine-schema-postgres:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://db:db@127.0.0.1:5432/db?serverVersion=16&charset=utf8
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["8.3"]
+    name: Validate Doctrine Schema on Postgres (PHP ${{ matrix.php }})
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: db
+          POSTGRES_PASSWORD: db
+          POSTGRES_DB: db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U db -d db"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php}}
+          # pgsql/pdo_pgsql added on top of the standard extension list so
+          # Doctrine can connect to Postgres for the portability gate.
+          extensions: apcu, ctype, iconv, imagick, json, pdo_pgsql, pgsql, redis, soap, xmlreader, zip
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ matrix.php }}-composer-
+
+      - name: 'Composer install with exported .env variables'
+        run: |
+          set -a && source .env && set +a
+          APP_ENV=prod composer install --no-dev -o
+
+      # The 2.x historical migrations use raw MariaDB SQL and can't run on
+      # Postgres — that's the whole reason this PR exists. We instead apply
+      # the entity layer directly via schema:update, which tests the
+      # load-bearing claim that the *metadata* (after the rename) is
+      # platform-portable. doctrine:schema:validate then catches any drift
+      # between Postgres' generated DDL and what Doctrine expects.
+      - name: Apply entity metadata to Postgres (schema:update)
+        run: APP_ENV=prod php bin/console doctrine:schema:update --force --complete --no-interaction
+
+      - name: Validate Doctrine schema (Postgres)
+        run: APP_ENV=prod php bin/console doctrine:schema:validate
+
   php-cs-fixer:
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - [#444](https://github.com/os2display/display-api-service/pull/444)
-  - Renamed 15 `changed_idx` indexes to `<table>_changed_idx` for cross-platform portability (Postgres scopes index names schema-wide).
+  - Renamed 15 `changed_idx` indexes to `<table>_changed_idx` for cross-platform portability
+    (Postgres scopes index names schema-wide).
   - Quoted `user` table identifier in entity metadata so Doctrine emits the platform-native quote on every reference.
-  - Added Postgres CI gate that runs `doctrine:schema:update --force --complete` + `doctrine:schema:validate` against a Postgres 16 service container.
+  - Added Postgres CI gate that runs `doctrine:schema:update --force --complete` +
+    `doctrine:schema:validate` against a Postgres 16 service container.
 
 ## [2.7.1] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [2.7.0] - 2026-05-01
-
 - [#444](https://github.com/os2display/display-api-service/pull/444)
   - Renamed 15 `changed_idx` indexes to `<table>_changed_idx` for cross-platform portability (Postgres scopes index names schema-wide).
   - Quoted `user` table identifier in entity metadata so Doctrine emits the platform-native quote on every reference.
   - Added Postgres CI gate that runs `doctrine:schema:update --force --complete` + `doctrine:schema:validate` against a Postgres 16 service container.
+
+## [2.7.0] - 2026-05-01
+
 - [#363](https://github.com/os2display/display-api-service/pull/363)
   - Added optional 'area' and 'facility' configuration fields
 - [#362](https://github.com/os2display/display-api-service/pull/362)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.7.0] - 2026-05-01
 
-- [#PR](https://github.com/os2display/display-api-service/pull/PR)
+- [#444](https://github.com/os2display/display-api-service/pull/444)
   - Renamed 15 `changed_idx` indexes to `<table>_changed_idx` for cross-platform portability (Postgres scopes index names schema-wide).
   - Quoted `user` table identifier in entity metadata so Doctrine emits the platform-native quote on every reference.
   - Added Postgres CI gate that runs `doctrine:schema:update --force --complete` + `doctrine:schema:validate` against a Postgres 16 service container.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [2.7.0] - 2026-05-01
 
+- [#PR](https://github.com/os2display/display-api-service/pull/PR)
+  - Renamed 15 `changed_idx` indexes to `<table>_changed_idx` for cross-platform portability (Postgres scopes index names schema-wide).
+  - Quoted `user` table identifier in entity metadata so Doctrine emits the platform-native quote on every reference.
+  - Added Postgres CI gate that runs `doctrine:schema:update --force --complete` + `doctrine:schema:validate` against a Postgres 16 service container.
 - [#363](https://github.com/os2display/display-api-service/pull/363)
   - Added optional 'area' and 'facility' configuration fields
 - [#362](https://github.com/os2display/display-api-service/pull/362)

--- a/migrations/Version20260507120000.php
+++ b/migrations/Version20260507120000.php
@@ -12,7 +12,7 @@ use Doctrine\Migrations\AbstractMigration;
  * they don't collide on platforms (such as Postgres) that scope index names
  * schema-wide rather than per-table.
  *
- * No-op for MariaDB at runtime. Landing on 2.7 means the consolidated 3.0
+ * No-op for MariaDB at runtime. Landing on 2.8 means the consolidated 3.0
  * migration can emit the portable shape from the start, keeping
  * `migrations:rollup` honest for 2.x → 3.0 upgraders. The reserved-keyword
  * problem with the `user` table is handled separately by backtick-quoting

--- a/migrations/Version20260507120000.php
+++ b/migrations/Version20260507120000.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Portability prep: give the 15 `changed_idx` indexes table-scoped names so
+ * they don't collide on platforms (such as Postgres) that scope index names
+ * schema-wide rather than per-table.
+ *
+ * No-op for MariaDB at runtime. Landing on 2.7 means the consolidated 3.0
+ * migration can emit the portable shape from the start, keeping
+ * `migrations:rollup` honest for 2.x → 3.0 upgraders. The reserved-keyword
+ * problem with the `user` table is handled separately by backtick-quoting
+ * the identifier in the entity attribute (no rename needed).
+ */
+final class Version20260507120000 extends AbstractMigration
+{
+    private const CHANGED_IDX_TABLES = [
+        'feed',
+        'feed_source',
+        'media',
+        'playlist',
+        'playlist_screen_region',
+        'playlist_slide',
+        'screen',
+        'screen_campaign',
+        'screen_group',
+        'screen_group_campaign',
+        'screen_layout',
+        'screen_layout_regions',
+        'slide',
+        'template',
+        'theme',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Uniquify the 15 `changed_idx` indexes (table-scoped names) for cross-platform portability.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::CHANGED_IDX_TABLES as $table) {
+            $this->addSql(sprintf('ALTER TABLE `%s` RENAME INDEX `changed_idx` TO `%s_changed_idx`', $table, $table));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::CHANGED_IDX_TABLES as $table) {
+            $this->addSql(sprintf('ALTER TABLE `%s` RENAME INDEX `%s_changed_idx` TO `changed_idx`', $table, $table));
+        }
+    }
+}

--- a/src/Entity/ScreenLayout.php
+++ b/src/Entity/ScreenLayout.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ScreenLayoutRepository::class)]
 #[ORM\EntityListeners([\App\EventListener\ScreenLayoutDoctrineEventListener::class])]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'screen_layout_changed_idx')]
 class ScreenLayout extends AbstractBaseEntity implements MultiTenantInterface, RelationsChecksumInterface
 {
     use MultiTenantTrait;

--- a/src/Entity/ScreenLayoutRegions.php
+++ b/src/Entity/ScreenLayoutRegions.php
@@ -17,7 +17,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: ScreenLayoutRegionsRepository::class)]
 #[ORM\EntityListeners([\App\EventListener\ScreenLayoutRegionsDoctrineEventListener::class])]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'screen_layout_regions_changed_idx')]
 class ScreenLayoutRegions extends AbstractBaseEntity implements MultiTenantInterface, RelationsChecksumInterface
 {
     use MultiTenantTrait;

--- a/src/Entity/Template.php
+++ b/src/Entity/Template.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: TemplateRepository::class)]
 #[ORM\EntityListeners([\App\EventListener\TemplateDoctrineEventListener::class])]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'template_changed_idx')]
 class Template extends AbstractBaseEntity implements MultiTenantInterface, RelationsChecksumInterface
 {
     use MultiTenantTrait;

--- a/src/Entity/Tenant/Feed.php
+++ b/src/Entity/Tenant/Feed.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: FeedRepository::class)]
 #[ORM\EntityListeners([\App\EventListener\FeedDoctrineEventListener::class])]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'feed_changed_idx')]
 class Feed extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use RelationsChecksumTrait;

--- a/src/Entity/Tenant/FeedSource.php
+++ b/src/Entity/Tenant/FeedSource.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: FeedSourceRepository::class)]
 #[ORM\EntityListeners([\App\EventListener\FeedSourceDoctrineEventListener::class])]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'feed_source_changed_idx')]
 class FeedSource extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use EntityTitleDescriptionTrait;

--- a/src/Entity/Tenant/Media.php
+++ b/src/Entity/Tenant/Media.php
@@ -18,7 +18,7 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
 #[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: MediaRepository::class)]
 #[ORM\EntityListeners([\App\EventListener\MediaDoctrineEventListener::class])]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'media_changed_idx')]
 class Media extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use EntityTitleDescriptionTrait;

--- a/src/Entity/Tenant/Playlist.php
+++ b/src/Entity/Tenant/Playlist.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Collections\Order;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: PlaylistRepository::class)]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'playlist_changed_idx')]
 class Playlist extends AbstractTenantScopedEntity implements MultiTenantInterface, RelationsChecksumInterface
 {
     use EntityPublishedTrait;

--- a/src/Entity/Tenant/PlaylistScreenRegion.php
+++ b/src/Entity/Tenant/PlaylistScreenRegion.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\UniqueConstraint(name: 'unique_playlist_screen_region', columns: ['playlist_id', 'screen_id', 'region_id'])]
 #[ORM\Entity(repositoryClass: PlaylistScreenRegionRepository::class)]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'playlist_screen_region_changed_idx')]
 class PlaylistScreenRegion extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use RelationsChecksumTrait;

--- a/src/Entity/Tenant/PlaylistSlide.php
+++ b/src/Entity/Tenant/PlaylistSlide.php
@@ -10,7 +10,7 @@ use App\Repository\PlaylistSlideRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: PlaylistSlideRepository::class)]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'playlist_slide_changed_idx')]
 class PlaylistSlide extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use RelationsChecksumTrait;

--- a/src/Entity/Tenant/Screen.php
+++ b/src/Entity/Tenant/Screen.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ScreenRepository::class)]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'screen_changed_idx')]
 class Screen extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use EntityTitleDescriptionTrait;

--- a/src/Entity/Tenant/ScreenCampaign.php
+++ b/src/Entity/Tenant/ScreenCampaign.php
@@ -10,7 +10,7 @@ use App\Repository\ScreenCampaignRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ScreenCampaignRepository::class)]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'screen_campaign_changed_idx')]
 class ScreenCampaign extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use RelationsChecksumTrait;

--- a/src/Entity/Tenant/ScreenGroup.php
+++ b/src/Entity/Tenant/ScreenGroup.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ScreenGroupRepository::class)]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'screen_group_changed_idx')]
 class ScreenGroup extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use EntityTitleDescriptionTrait;

--- a/src/Entity/Tenant/ScreenGroupCampaign.php
+++ b/src/Entity/Tenant/ScreenGroupCampaign.php
@@ -10,7 +10,7 @@ use App\Repository\ScreenGroupCampaignRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ScreenGroupCampaignRepository::class)]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'screen_group_campaign_changed_idx')]
 class ScreenGroupCampaign extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use RelationsChecksumTrait;

--- a/src/Entity/Tenant/Slide.php
+++ b/src/Entity/Tenant/Slide.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: SlideRepository::class)]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'slide_changed_idx')]
 class Slide extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use EntityPublishedTrait;

--- a/src/Entity/Tenant/Theme.php
+++ b/src/Entity/Tenant/Theme.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ThemeRepository::class)]
 #[ORM\EntityListeners([\App\EventListener\ThemeDoctrineEventListener::class])]
-#[ORM\Index(fields: ['changed'], name: 'changed_idx')]
+#[ORM\Index(fields: ['changed'], name: 'theme_changed_idx')]
 class Theme extends AbstractTenantScopedEntity implements RelationsChecksumInterface
 {
     use EntityTitleDescriptionTrait;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
+#[ORM\Table(name: '`user`')]
 class User extends AbstractBaseEntity implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSerializable, TenantScopedUserInterface
 {
     #[Assert\NotBlank]


### PR DESCRIPTION
> [!NOTE]
> Targets `release/2.8.0`. Lands here so the consolidated 3.0 migration in #441 / #442 can be regenerated against the portable entity shape and `migrations:rollup` stays honest for 2.x → 3.0 upgraders.

## Why

Two things in the current schema are MariaDB-only and block fresh Postgres installs:

1. **`changed_idx` index name reused on 15 tables.** MariaDB scopes index names per-table; Postgres scopes them schema-wide, so the second `CREATE INDEX changed_idx` collides with `relation "changed_idx" already exists`.
2. **`user` table is reserved in standard SQL and in Postgres.** Doctrine doesn't auto-quote it, so generated DML like `INSERT INTO user (...)` is a syntax error on Postgres.

Without resolving these on 2.8, the consolidated 3.0 migration can't emit a Postgres-portable shape — it has to match what 2.x → 3.0 upgraders' MariaDB already has, or `migrations:rollup` lies. Fixing the divergence on 2.8 first means upgraders converge to the portable shape before they ever touch 3.0.

## What

- **Migration `Version20260507120000`** — `RENAME INDEX changed_idx TO <table>_changed_idx` on the 15 affected tables (`feed`, `feed_source`, `media`, `playlist`, `playlist_screen_region`, `playlist_slide`, `screen`, `screen_campaign`, `screen_group`, `screen_group_campaign`, `screen_layout`, `screen_layout_regions`, `slide`, `template`, `theme`). Reversible. No-op for MariaDB at runtime.
- **Entity metadata** — 15 `#[ORM\Index(name: 'changed_idx')]` updated to `<table>_changed_idx`; `User` entity gets `#[ORM\Table(name: '\`user\`')]` so Doctrine emits the platform-native quoted identifier on every reference.
- **CI gate** — new `validate-doctrine-schema-postgres` job in `pr.yaml` spins up a Postgres 16 service container, applies entity metadata via `doctrine:schema:update --force --complete`, then runs `doctrine:schema:validate`. Catches future entity changes that break Postgres compatibility.

## Why backtick-quote `user` instead of renaming it

A rename (`user` → `app_user`) was the first approach considered but it requires touching every table that FKs into `user`, plus realigning Doctrine's auto-derived hash-based index names (`UNIQ_8D93D649…` → `UNIQ_88BDF3E9…`). Backtick-quoting the identifier in the entity attribute is the standard Doctrine mechanism for reserved words: zero schema change, Doctrine emits `` `user` `` on MariaDB and `"user"` on Postgres from the same metadata. Trade-off accepted: any raw SQL outside Doctrine that hardcodes `user` would still need quoting on Postgres — but the only known instances (`MultiTenantRepositoryTrait`, `RelationsChecksumCalculator`) are deferred MariaDB-only paths called out in #442's "Out of scope" section anyway.

## Test plan

- [x] MariaDB: `doctrine:migrations:migrate` applies all 26 migrations cleanly; `doctrine:schema:validate` is in sync; full PHPUnit suite green (133 tests / 516 assertions, byte-identical to pristine `release/2.7.0` baseline this PR was originally cut from).
- [x] MariaDB: down/up cycle of the new migration verified.
- [x] Postgres 16: `doctrine:schema:update --force --complete` applies entity metadata in 265 queries; `doctrine:schema:validate` is in sync; `user` table is created, no `changed_idx` collision.
- [ ] Retest against `release/2.8.0` baseline after retarget.
- [ ] CI green on this PR (the new Postgres job is the proof point).

## Follow-ups (not in this PR)

- After merge: regenerate `Version20260506215847` in #441 against the new entity shape so 3.0 fresh installs (on MariaDB or Postgres) emit the portable form. #442's Schema-tool conversion stays intact — the regenerated DDL just uses the new index/identifier names.
- Native MariaDB SQL in `MultiTenantRepositoryTrait` and `RelationsChecksumCalculator` (deferred per #442 description) still blocks Postgres at runtime; those need a separate conversion before Postgres becomes a real install target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)