### PR TITLE
feat(logging): [1/4] structured-logging foundation — channels + context processors + auth subscriber

### DIFF
--- a/.env
+++ b/.env
@@ -124,6 +124,30 @@ HTTP_CLIENT_MAX_DURATION=30
 HTTP_CLIENT_LOG_LEVEL=error
 ###< Http Client ###
 
+###> Logging ###
+# Log output destination. php://stderr suits container deployments (Docker
+# captures it). Bare-metal nginx + php-fpm checkouts may set a file path, e.g.
+# LOG_PATH=%kernel.logs_dir%/prod.log (the operator owns rotation/permissions).
+# Image/container deployments must keep php://stderr.
+LOG_PATH=php://stderr
+# Global log level for the application domain channels
+# (debug, info, notice, warning, error, critical). info reproduces prior output.
+LOG_LEVEL=info
+# Per-channel override; empty or unset inherits LOG_LEVEL.
+LOG_LEVEL_AUTH=
+# Per-channel override; empty or unset inherits LOG_LEVEL.
+LOG_LEVEL_SCREEN=
+# Per-channel override; empty or unset inherits LOG_LEVEL.
+LOG_LEVEL_MEDIA=
+# Per-channel override; empty or unset inherits LOG_LEVEL.
+LOG_LEVEL_FEED=
+# Per-channel override; empty or unset inherits LOG_LEVEL.
+LOG_LEVEL_INTERACTIVE=
+# Threshold for Symfony's built-in cache channel (cache-adapter/Redis failures);
+# not an application channel. Empty or unset inherits LOG_LEVEL.
+LOG_LEVEL_CACHE=
+###< Logging ###
+
 ###> App ###
 # Default date format for API responses (ISO 8601 with milliseconds).
 DEFAULT_DATE_FORMAT='Y-m-d\TH:i:s.v\Z'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
   `http_client_options.timeout` on both providers, configurable via the new `OIDC_HTTP_TIMEOUT` env var
   (default 5s). Previously no timeout was set anywhere in the chain, so Guzzle waited indefinitely and a
   hung/slow IdP could tie up a php-fpm worker.
+- Added structured, channel-split application logging (ADR 011): per-domain Monolog channels
+  (`auth`, `screen`, `media`, `feed`, `interactive`, `cache`) with per-channel prod handlers
+  thresholded by `LOG_LEVEL_<CHANNEL>` (falling back to a global `LOG_LEVEL`), a configurable
+  `LOG_PATH` output destination (default `php://stderr`), request/identity/trace-context
+  processors, request-id propagation via `X-Request-Id`, and an auth-event logging subscriber.
+- Renamed the outbound-HTTP-client log channel `app_http` → `outbound_http` and silenced
+  Symfony's redundant native `http_client` channel logging (a `NullLogger` decorates it), so
+  `LoggingHttpClient` is the single source of outbound-HTTP logs (no duplicate request logging).
 - Removed the deprecated feed types `SparkleIOFeedType`, `EventDatabaseApiFeedType` and `KobaFeedType`.
   Made the unknown-feed-type handling consistent: **reads degrade, writes are rejected.** Feed sources
   (and feeds) that reference a removed type keep loading — item and collection reads return them with no

--- a/README.md
+++ b/README.md
@@ -562,6 +562,39 @@ MEDIA_MAX_UPLOAD_SIZE_MB=200
   Changes are picked up on the next request once PHP-FPM workers see the new env value (in production, restart the
   php-fpm container or reload the workers). The admin UI re-fetches `/config/admin` on the next page load.
 
+### Logging
+
+Structured JSON logging on per-domain channels (see [ADR 011](docs/adr/011-structured-logging.md) and
+[docs/logging.md](docs/logging.md)). Each domain channel has a production stream handler whose threshold is
+`LOG_LEVEL_<CHANNEL>`, falling back to the global `LOG_LEVEL` when the per-channel value is empty or unset.
+
+```dotenv
+###> Logging ###
+LOG_PATH=php://stderr
+LOG_LEVEL=info
+LOG_LEVEL_AUTH=
+LOG_LEVEL_SCREEN=
+LOG_LEVEL_MEDIA=
+LOG_LEVEL_FEED=
+LOG_LEVEL_INTERACTIVE=
+LOG_LEVEL_CACHE=
+###< Logging ###
+```
+
+- LOG_PATH: Destination for the production log handlers. Defaults to `php://stderr`, which suits container
+  deployments (the runtime captures stderr). Bare-metal nginx + php-fpm deployments may point it at a file
+  (e.g. `%kernel.logs_dir%/prod.log`); the operator then owns log rotation and the php-fpm user's write permission
+  to the directory. Image/container deployments must keep `php://stderr`.
+
+  **Default**: `php://stderr`.
+- LOG_LEVEL: Global log level for the application domain channels (`debug`, `info`, `notice`, `warning`, `error`,
+  `critical`). `info` reproduces the previous output.
+
+  **Default**: `info`.
+- LOG_LEVEL_AUTH, LOG_LEVEL_SCREEN, LOG_LEVEL_MEDIA, LOG_LEVEL_FEED, LOG_LEVEL_INTERACTIVE, LOG_LEVEL_CACHE:
+  Per-channel threshold overrides. Empty or unset inherits `LOG_LEVEL`. Set one to raise or lower a single channel
+  (e.g. `LOG_LEVEL_FEED=warning`) without affecting the others. An invalid level fails fast at boot.
+
 ### Admin configuration
 
 Will be exposed through the `/config/admin` route.

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,2 +1,11 @@
 monolog:
-    channels: ['app_http']
+    channels:
+        [
+            'outbound_http',
+            'auth',
+            'screen',
+            'media',
+            'feed',
+            'interactive',
+            'cache',
+        ]

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -8,14 +8,59 @@ monolog:
             buffer_size: 50 # How many messages should be saved? Prevent memory leaks
         nested:
             type: stream
-            path: php://stderr
+            path: '%env(resolve:LOG_PATH)%'
             level: debug
             formatter: monolog.formatter.json
-        app_http:
+        outbound_http:
             type: stream
-            path: php://stderr
+            path: '%env(resolve:LOG_PATH)%'
             level: info
-            channels: ['app_http']
+            channels: ['outbound_http']
+            formatter: monolog.formatter.json
+        # One always-on handler per domain channel. A Monolog handler carries a
+        # single level, so per-channel thresholds require per-channel handlers.
+        # Each level falls back to the global LOG_LEVEL (app.log_level) when its
+        # LOG_LEVEL_<CHANNEL> override is empty or unset.
+        auth:
+            type: stream
+            path: '%env(resolve:LOG_PATH)%'
+            level: '%env(default:app.log_level:LOG_LEVEL_AUTH)%'
+            channels: ['auth']
+            formatter: monolog.formatter.json
+        screen:
+            type: stream
+            path: '%env(resolve:LOG_PATH)%'
+            level: '%env(default:app.log_level:LOG_LEVEL_SCREEN)%'
+            channels: ['screen']
+            formatter: monolog.formatter.json
+        media:
+            type: stream
+            path: '%env(resolve:LOG_PATH)%'
+            level: '%env(default:app.log_level:LOG_LEVEL_MEDIA)%'
+            channels: ['media']
+            formatter: monolog.formatter.json
+        feed:
+            type: stream
+            path: '%env(resolve:LOG_PATH)%'
+            level: '%env(default:app.log_level:LOG_LEVEL_FEED)%'
+            channels: ['feed']
+            formatter: monolog.formatter.json
+        interactive:
+            type: stream
+            path: '%env(resolve:LOG_PATH)%'
+            level: '%env(default:app.log_level:LOG_LEVEL_INTERACTIVE)%'
+            channels: ['interactive']
+            formatter: monolog.formatter.json
+        # Symfony's built-in cache channel — NOT an application channel. The cache
+        # adapters (the Redis pools) log backend failures here (failed save/fetch,
+        # connection drops) at `warning`; this dedicated handler surfaces them, since
+        # the `fingers_crossed` gate (action_level: error) would otherwise buffer and
+        # drop a standalone warning. No application code writes to this channel.
+        cache:
+            type: stream
+            path: '%env(resolve:LOG_PATH)%'
+            level: '%env(default:app.log_level:LOG_LEVEL_CACHE)%'
+            channels: ['cache']
             formatter: monolog.formatter.json
         console:
             type: console

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -81,9 +81,19 @@ services:
         tags: [{ name: monolog.processor }]
 
     # Logs security outcomes on the `auth` channel (logging only).
+    #
+    # Channel loggers are bound explicitly rather than via MonologBundle's channel
+    # autowiring. The constructor parameter is named for its channel
+    # (`$authLogger`, `$feedLogger`, …) so the call site reads clearly, but the
+    # explicit `@monolog.logger.<channel>` binding is the authoritative wiring:
+    # it fails loudly at container build if the channel id is wrong or the
+    # parameter is renamed, whereas the autowiring convention would silently fall
+    # back to the default `app` channel — a misroute neither container
+    # compilation nor PHPStan can catch. The parameter name and the binding must
+    # agree; the container enforces it.
     App\Logger\EventSubscriber\AuthLoggingSubscriber:
         arguments:
-            $logger: '@monolog.logger.auth'
+            $authLogger: '@monolog.logger.auth'
 
     Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface: '@Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationFailureHandler'
     Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface: '@Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,9 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    # Global fallback log level for the per-domain Monolog channels. Each
+    # LOG_LEVEL_<CHANNEL> override inherits this when empty/unset (ADR 011).
+    app.log_level: '%env(LOG_LEVEL)%'
 
 services:
     # default configuration for services in *this* file
@@ -52,10 +55,30 @@ services:
         decorates: http_client
         arguments:
             $client: '@.inner'
-            $logger: '@monolog.logger.app_http'
+            $logger: '@monolog.logger.outbound_http'
             $logLevel: '%env(string:HTTP_CLIENT_LOG_LEVEL)%'
 
+    # Silence Symfony's native http_client logging at the source: it is
+    # request-only and redundant with LoggingHttpClient (outbound_http channel),
+    # which is the single, OTel-shaped source of outbound-HTTP logs. A NullLogger
+    # replaces the channel logger the framework injects into the native client.
+    app.null_http_client_logger:
+        class: Psr\Log\NullLogger
+        decorates: monolog.logger.http_client
+
     #### App Scope below ###
+
+    # Structured logging: enrich every record with request/identity/trace context.
+    App\Logger\Processor\RequestContextProcessor:
+        tags: [{ name: monolog.processor }]
+
+    App\Logger\Processor\TraceContextProcessor:
+        tags: [{ name: monolog.processor }]
+
+    # Logs security outcomes on the `auth` channel (logging only).
+    App\Logger\EventSubscriber\AuthLoggingSubscriber:
+        arguments:
+            $logger: '@monolog.logger.auth'
 
     Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface: '@Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationFailureHandler'
     Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface: '@Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler'

--- a/docs/adr/011-structured-logging.md
+++ b/docs/adr/011-structured-logging.md
@@ -1,0 +1,90 @@
+# ADR 011 - Structured application logging
+
+Date: 02-06-2026
+
+## Status
+
+Accepted
+
+## Context
+
+Logging in `display-api-service` was a single Monolog channel (`app_http`) used only by
+`LoggingHttpClient`, with `fingers_crossed` (action level `error`) writing JSON to
+`php://stderr` in production. Log records carried no request, identity, or tenant context,
+and ~14 catch sites swallowed exceptions with no log and no rethrow. As a result, several
+documented production failures were invisible end-to-end: kiosk black-screens, missing
+thumbnails (PR #374), empty interactive booking results, and OIDC/JWT/refresh outcomes.
+
+Operators of single-server deployments frequently cannot run or monitor MariaDB directly
+(no shell access to the database, no metrics scraper). The application log is therefore the
+only place a database **connection** failure (too-many-connections, connection refused,
+server gone away) can surface.
+
+## Decision
+
+1. **Channel splitting.** Declare per-domain application channels (`auth`, `screen`, `media`,
+   `feed`, `interactive`, and `database`) alongside the outbound-HTTP channel `outbound_http`
+   (`LoggingHttpClient`, renamed from `app_http`). Symfony's built-in `cache` channel is
+   additionally given a dedicated handler — not for application logging (no application code
+   writes to it), but so cache-adapter (Redis) backend failures surface instead of being
+   buffered and dropped by the `fingers_crossed` error gate. Symfony's native `http_client`
+   channel logging is silenced (see Consequences) so `outbound_http` is the single,
+   OTel-shaped source of outbound-HTTP logs.
+
+2. **Context processors.** Every log record is enriched by Monolog processors with request
+   context (request id, route, method), identity (user or screen id, tenant key), W3C trace
+   context when present, GDPR-safe client address (truncated), and structured exception
+   serialization under a single `exception` context key. Field names follow OpenTelemetry
+   semantic conventions as strictly as the framework allows: `http.route` is the matched
+   route's **path template** (e.g. `/v2/screens/{id}`), emitted only when a route matched
+   and never the concrete id-bearing URL (which is recorded separately as `url.path`);
+   `client.address` is truncated; identity is `enduser.id` XOR `screen.id` plus `tenant.key`.
+
+3. **No silent failures.** Catch blocks must log the exception, rethrow it (optionally
+   wrapped), or be explicitly annotated as intentionally silent. This is enforced in CI by
+   project-local PHPStan rules (`logging.silentCatch`, `logging.interpolatedLogMessage`,
+   `logging.exceptionContextKey`).
+
+4. **Database connection-error logging.** A DBAL driver middleware logs connection
+   establishment failures on the `database` channel, classified by the raw driver error
+   code, so the failure is visible regardless of whether application code swallows the
+   exception and regardless of which SAPI (web, CLI, Messenger) opened the connection.
+
+5. **Output destination is configurable, defaulting to `php://stderr`.** Handlers write to
+   a `LOG_PATH` env var (default `php://stderr`). The default suits the Docker image
+   deployment, where the runtime captures stderr. Operators who run the repo directly under
+   nginx + php-fpm (no container) can set `LOG_PATH` to a file, because php-fpm does not
+   capture worker stderr cleanly. Per-channel thresholds are set with `LOG_LEVEL_<CHANNEL>`
+   env vars that fall back to a global `LOG_LEVEL`. Shipping logs onward to an aggregator
+   (OTel Collector / Loki / Grafana) remains a separate concern in `os2display-docker-server`
+   and is not decided here. Records stay JSON regardless of destination.
+
+6. **OpenTelemetry-first.** All logging follows OpenTelemetry semantic conventions and
+   naming as closely as the framework allows — attribute names, value shapes, and severity
+   levels. When Symfony/Monolog cannot express a convention exactly, the closest compliant
+   form is chosen over a bespoke field (e.g. `http.route` carries the route path template,
+   not the Symfony route name; attributes that don't apply are omitted rather than set to a
+   placeholder). New log fields must reuse an existing OTel attribute where one fits before
+   inventing a name. This keeps the logs forward-compatible with an OTel collector, should
+   one be introduced.
+
+## Consequences
+
+- Contributors must attach context via the PSR-3 context array (not string interpolation)
+  and must never swallow exceptions silently; the PHPStan gate fails the build otherwise.
+  The conventions are documented in `docs/logging.md`.
+- Operators gain a failure signal for database connection problems without database access,
+  at the cost of it being reactive (per-failure events, not "approaching the limit" trends).
+- The connection-error middleware covers connection **establishment** only; mid-query drops
+  (`2006`/`2013`) are out of its current scope and would require also wrapping the
+  connection's execution path.
+- Adopting OpenTelemetry semantic conventions for field names keeps logs forward-compatible
+  with an OTel collector, should one be introduced later.
+- Symfony's native `http_client` logging is silenced at the source — a `NullLogger` decorates
+  the `monolog.logger.http_client` service the framework injects into the native client (it is
+  request-only and redundant). `LoggingHttpClient` (`outbound_http` channel) is therefore the
+  single, OTel-shaped source of outbound-HTTP logs — no duplicate request logging.
+- `LOG_PATH` must stay `php://stderr` in the image deployment — pointing it at a
+  container-internal file breaks `task logs` and the planned filelog collector. Bare-metal
+  operators choosing a file own its rotation (e.g. logrotate) and the php-fpm user's write
+  permission to the log directory.

--- a/docs/adr/011-structured-logging.md
+++ b/docs/adr/011-structured-logging.md
@@ -38,7 +38,7 @@ server gone away) can surface.
    semantic conventions as strictly as the framework allows: `http.route` is the matched
    route's **path template** (e.g. `/v2/screens/{id}`), emitted only when a route matched
    and never the concrete id-bearing URL (which is recorded separately as `url.path`);
-   `client.address` is truncated; identity is `enduser.id` XOR `screen.id` plus `tenant.key`.
+   `client.address` is truncated; identity is `user.id` XOR `screen.id` plus `tenant.key`.
 
 3. **No silent failures.** Catch blocks must log the exception, rethrow it (optionally
    wrapped), or be explicitly annotated as intentionally silent. This is enforced in CI by

--- a/src/Logger/EventSubscriber/AuthLoggingSubscriber.php
+++ b/src/Logger/EventSubscriber/AuthLoggingSubscriber.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logger\EventSubscriber;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTExpiredEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTFailureEventInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events as LexikEvents;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+/**
+ * Logs security outcomes on the `auth` channel.
+ *
+ * This subscriber only logs — it does not alter authentication behaviour. The
+ * JWT payload/tenant injection lives in the dedicated Lexik listeners
+ * (AuthenticationSuccessListener, JWTCreatedListener, JwtTokenRefreshedSubscriber)
+ * and must not be duplicated here.
+ *
+ * Token strings and credentials are never logged; only identifiers, firewall
+ * names and exception messages are.
+ */
+final readonly class AuthLoggingSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {}
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LoginSuccessEvent::class => 'onLoginSuccess',
+            LoginFailureEvent::class => 'onLoginFailure',
+            LogoutEvent::class => 'onLogout',
+            LexikEvents::JWT_INVALID => 'onJwtFailure',
+            LexikEvents::JWT_EXPIRED => 'onJwtFailure',
+            LexikEvents::JWT_NOT_FOUND => 'onJwtFailure',
+        ];
+    }
+
+    public function onLoginSuccess(LoginSuccessEvent $event): void
+    {
+        $this->logger->info('Authentication succeeded', [
+            'event' => 'auth.login_success',
+            'user_identifier' => $event->getUser()->getUserIdentifier(),
+            'firewall' => $event->getFirewallName(),
+            'authenticator' => $event->getAuthenticator()::class,
+        ]);
+    }
+
+    public function onLoginFailure(LoginFailureEvent $event): void
+    {
+        $this->logger->warning('Authentication failed', [
+            'event' => 'auth.login_failure',
+            'firewall' => $event->getFirewallName(),
+            'authenticator' => $event->getAuthenticator()::class,
+            'exception' => $event->getException(),
+        ]);
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        $this->logger->info('User logged out', [
+            'event' => 'auth.logout',
+            'user_identifier' => $event->getToken()?->getUserIdentifier(),
+        ]);
+    }
+
+    public function onJwtFailure(JWTFailureEventInterface $event): void
+    {
+        $this->logger->warning('JWT authentication failed', [
+            'event' => 'auth.jwt_failure',
+            'reason' => match (true) {
+                $event instanceof JWTInvalidEvent => 'invalid',
+                $event instanceof JWTExpiredEvent => 'expired',
+                $event instanceof JWTNotFoundEvent => 'not_found',
+                default => 'unknown',
+            },
+            'exception' => $event->getException(),
+        ]);
+    }
+}

--- a/src/Logger/EventSubscriber/AuthLoggingSubscriber.php
+++ b/src/Logger/EventSubscriber/AuthLoggingSubscriber.php
@@ -29,7 +29,7 @@ use Symfony\Component\Security\Http\Event\LogoutEvent;
 final readonly class AuthLoggingSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private LoggerInterface $logger,
+        private LoggerInterface $authLogger,
     ) {}
 
     public static function getSubscribedEvents(): array
@@ -46,7 +46,7 @@ final readonly class AuthLoggingSubscriber implements EventSubscriberInterface
 
     public function onLoginSuccess(LoginSuccessEvent $event): void
     {
-        $this->guard(fn () => $this->logger->info('Authentication succeeded', [
+        $this->guard(fn () => $this->authLogger->info('Authentication succeeded', [
             'event' => 'auth.login_success',
             'user_identifier' => $event->getUser()->getUserIdentifier(),
             'firewall' => $event->getFirewallName(),
@@ -56,7 +56,7 @@ final readonly class AuthLoggingSubscriber implements EventSubscriberInterface
 
     public function onLoginFailure(LoginFailureEvent $event): void
     {
-        $this->guard(fn () => $this->logger->warning('Authentication failed', [
+        $this->guard(fn () => $this->authLogger->warning('Authentication failed', [
             'event' => 'auth.login_failure',
             'firewall' => $event->getFirewallName(),
             'authenticator' => $event->getAuthenticator()::class,
@@ -66,7 +66,7 @@ final readonly class AuthLoggingSubscriber implements EventSubscriberInterface
 
     public function onLogout(LogoutEvent $event): void
     {
-        $this->guard(fn () => $this->logger->info('User logged out', [
+        $this->guard(fn () => $this->authLogger->info('User logged out', [
             'event' => 'auth.logout',
             'user_identifier' => $event->getToken()?->getUserIdentifier(),
         ]));
@@ -74,7 +74,7 @@ final readonly class AuthLoggingSubscriber implements EventSubscriberInterface
 
     public function onJwtFailure(JWTFailureEventInterface $event): void
     {
-        $this->guard(fn () => $this->logger->warning('JWT authentication failed', [
+        $this->guard(fn () => $this->authLogger->warning('JWT authentication failed', [
             'event' => 'auth.jwt_failure',
             'reason' => match (true) {
                 $event instanceof JWTInvalidEvent => 'invalid',

--- a/src/Logger/EventSubscriber/AuthLoggingSubscriber.php
+++ b/src/Logger/EventSubscriber/AuthLoggingSubscriber.php
@@ -46,35 +46,35 @@ final readonly class AuthLoggingSubscriber implements EventSubscriberInterface
 
     public function onLoginSuccess(LoginSuccessEvent $event): void
     {
-        $this->logger->info('Authentication succeeded', [
+        $this->guard(fn () => $this->logger->info('Authentication succeeded', [
             'event' => 'auth.login_success',
             'user_identifier' => $event->getUser()->getUserIdentifier(),
             'firewall' => $event->getFirewallName(),
             'authenticator' => $event->getAuthenticator()::class,
-        ]);
+        ]));
     }
 
     public function onLoginFailure(LoginFailureEvent $event): void
     {
-        $this->logger->warning('Authentication failed', [
+        $this->guard(fn () => $this->logger->warning('Authentication failed', [
             'event' => 'auth.login_failure',
             'firewall' => $event->getFirewallName(),
             'authenticator' => $event->getAuthenticator()::class,
             'exception' => $event->getException(),
-        ]);
+        ]));
     }
 
     public function onLogout(LogoutEvent $event): void
     {
-        $this->logger->info('User logged out', [
+        $this->guard(fn () => $this->logger->info('User logged out', [
             'event' => 'auth.logout',
             'user_identifier' => $event->getToken()?->getUserIdentifier(),
-        ]);
+        ]));
     }
 
     public function onJwtFailure(JWTFailureEventInterface $event): void
     {
-        $this->logger->warning('JWT authentication failed', [
+        $this->guard(fn () => $this->logger->warning('JWT authentication failed', [
             'event' => 'auth.jwt_failure',
             'reason' => match (true) {
                 $event instanceof JWTInvalidEvent => 'invalid',
@@ -83,6 +83,23 @@ final readonly class AuthLoggingSubscriber implements EventSubscriberInterface
                 default => 'unknown',
             },
             'exception' => $event->getException(),
-        ]);
+        ]));
+    }
+
+    /**
+     * Runs a logging closure, swallowing any failure.
+     *
+     * This subscriber observes authentication events; logging must never break
+     * them. Both the context building (identity accessors that can throw) and the
+     * write itself run inside the guard, so a logging failure drops the line
+     * rather than aborting login/logout.
+     */
+    private function guard(callable $log): void
+    {
+        try {
+            $log();
+        } catch (\Throwable) {
+            // Intentionally silent — see method doc.
+        }
     }
 }

--- a/src/Logger/EventSubscriber/RequestIdSubscriber.php
+++ b/src/Logger/EventSubscriber/RequestIdSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logger\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Adopts the inbound `X-Request-Id` (nginx-generated) or mints one, stores it on
+ * the request, and echoes it on the response. No format validation — the upstream
+ * proxy decides the format.
+ */
+final class RequestIdSubscriber implements EventSubscriberInterface
+{
+    private const ATTR = '_request_id';
+    private const HEADER = 'X-Request-Id';
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // High priority so the id exists before anything else logs.
+            KernelEvents::REQUEST => ['onRequest', 4096],
+            KernelEvents::RESPONSE => ['onResponse', -4096],
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+        $request = $event->getRequest();
+        $id = $request->headers->get(self::HEADER) ?: (string) Uuid::v4();
+        $request->attributes->set(self::ATTR, $id);
+    }
+
+    public function onResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+        $id = $event->getRequest()->attributes->get(self::ATTR);
+        if (null !== $id && !$event->getResponse()->headers->has(self::HEADER)) {
+            $event->getResponse()->headers->set(self::HEADER, $id);
+        }
+    }
+}

--- a/src/Logger/Processor/RequestContextProcessor.php
+++ b/src/Logger/Processor/RequestContextProcessor.php
@@ -48,22 +48,27 @@ final readonly class RequestContextProcessor implements ProcessorInterface
 
         $user = $this->security->getUser();
         if (null !== $user) {
-            // Screen tokens authenticate as ScreenUser; everything else is a
-            // back-office User. Populate screen_id XOR user_id accordingly.
-            if ($user instanceof ScreenUser) {
-                $record->extra['screen_id'] = (string) $user->getScreen()->getId();
-            } else {
-                $record->extra['user_id'] = $user->getUserIdentifier();
-            }
-
-            if ($user instanceof TenantScopedUserInterface) {
-                // getActiveTenant() can throw when no tenant is resolved yet;
-                // enrichment must never break the request it is annotating.
-                try {
-                    $record->extra['tenant_id'] = $user->getActiveTenant()->getTenantKey();
-                } catch (\Throwable) {
-                    // No active tenant on this request — leave tenant_id unset.
+            // Enrichment must never break the request it is annotating. Every
+            // identity accessor below can throw — getActiveTenant() when no tenant
+            // is resolved yet, getScreen() on a not-yet-hydrated screen token,
+            // getUserIdentifier() on a custom user — so the whole block is guarded.
+            // Fields written before a throw are kept (the record is mutated in
+            // place); the failing one and any after it are simply left unset.
+            try {
+                // Screen tokens authenticate as ScreenUser; everything else is a
+                // back-office User. Populate screen_id XOR user_id accordingly.
+                if ($user instanceof ScreenUser) {
+                    $record->extra['screen_id'] = (string) $user->getScreen()->getId();
+                } else {
+                    $record->extra['user_id'] = $user->getUserIdentifier();
                 }
+
+                if ($user instanceof TenantScopedUserInterface) {
+                    $record->extra['tenant_id'] = $user->getActiveTenant()->getTenantKey();
+                }
+            } catch (\Throwable) {
+                // An identity accessor failed (no active tenant, unhydrated screen,
+                // lazy-load error, …). Keep whatever was set; never break logging.
             }
         }
 

--- a/src/Logger/Processor/RequestContextProcessor.php
+++ b/src/Logger/Processor/RequestContextProcessor.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logger\Processor;
+
+use App\Entity\Interfaces\TenantScopedUserInterface;
+use App\Entity\ScreenUser;
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Enriches every log record with request and identity context.
+ *
+ * Field names here are the interim PR 1 names (request_id, route, method,
+ * user_id, screen_id, tenant_id); they are renamed to OpenTelemetry semantic
+ * conventions in a later change.
+ */
+final readonly class RequestContextProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private RequestStack $requestStack,
+        private Security $security,
+    ) {}
+
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $request = $this->requestStack->getMainRequest();
+        if (null !== $request) {
+            // No format validation — accept whatever nginx/Traefik passed through.
+            $record->extra['request_id'] = $request->attributes->get('_request_id')
+                ?? $request->headers->get('X-Request-Id');
+            // The matched route's declared path TEMPLATE, not the concrete URL:
+            // a request to `GET /v2/screens/01HXYZ…` is logged as
+            // `route = /v2/screens/{id}` — the entity id never appears in this
+            // field (low-cardinality, GDPR-safe; OTel `http.route` semantics).
+            // Only set when a route matched; the concrete id-bearing path is not
+            // logged here.
+            $routeTemplate = $this->routeTemplate($request);
+            if (null !== $routeTemplate) {
+                $record->extra['route'] = $routeTemplate;
+            }
+            $record->extra['method'] = $request->getMethod();
+        }
+
+        $user = $this->security->getUser();
+        if (null !== $user) {
+            // Screen tokens authenticate as ScreenUser; everything else is a
+            // back-office User. Populate screen_id XOR user_id accordingly.
+            if ($user instanceof ScreenUser) {
+                $record->extra['screen_id'] = (string) $user->getScreen()->getId();
+            } else {
+                $record->extra['user_id'] = $user->getUserIdentifier();
+            }
+
+            if ($user instanceof TenantScopedUserInterface) {
+                // getActiveTenant() can throw when no tenant is resolved yet;
+                // enrichment must never break the request it is annotating.
+                try {
+                    $record->extra['tenant_id'] = $user->getActiveTenant()->getTenantKey();
+                } catch (\Throwable) {
+                    // No active tenant on this request — leave tenant_id unset.
+                }
+            }
+        }
+
+        return $record;
+    }
+
+    /**
+     * The matched route's path template (OTel `http.route`), e.g.
+     * `/v2/screens/{id}` — never the concrete path with the id. Reconstructed
+     * from the request path by substituting the matched route parameters back to
+     * their `{name}` placeholders, with the optional API Platform `.{_format}`
+     * suffix stripped. Returns null when no route matched, so the field is only
+     * present for matched requests (per OTel guidance).
+     *
+     * This deliberately avoids injecting the router: depending on it forms a
+     * circular service graph with the `database` channel logger used by the DBAL
+     * connection middleware (processor → router → EntityManager → DBAL middleware
+     * → database logger → processor).
+     */
+    private function routeTemplate(Request $request): ?string
+    {
+        $routeName = $request->attributes->get('_route');
+        if (!is_string($routeName)) {
+            return null;
+        }
+
+        $params = $request->attributes->get('_route_params');
+        if (!is_array($params)) {
+            $params = [];
+        }
+
+        $path = $request->getPathInfo();
+        foreach ($params as $name => $value) {
+            // Skip framework params (_format, _locale, …); only real placeholders.
+            if (!is_string($name) || str_starts_with($name, '_') || !is_scalar($value)) {
+                continue;
+            }
+            $value = (string) $value;
+            if ('' !== $value) {
+                $path = str_replace($value, '{'.$name.'}', $path);
+            }
+        }
+
+        // Strip the optional API Platform format suffix (e.g. `.jsonld`).
+        $format = $params['_format'] ?? null;
+        if (is_string($format) && '' !== $format) {
+            $path = preg_replace('/\.'.preg_quote($format, '/').'$/', '', $path) ?? $path;
+        }
+
+        return $path;
+    }
+}

--- a/src/Logger/Processor/TraceContextProcessor.php
+++ b/src/Logger/Processor/TraceContextProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logger\Processor;
+
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Parses a W3C `traceparent` header when an upstream sends one, so log records
+ * can be correlated with a distributed trace if/when tracing is introduced.
+ * Nothing emits `traceparent` today; this is a no-op until something upstream
+ * does. The fields are simply absent when no (valid) header is present — never
+ * set to empty or garbage values.
+ */
+final readonly class TraceContextProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private RequestStack $requestStack,
+    ) {}
+
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $request = $this->requestStack->getMainRequest();
+        $traceparent = $request?->headers->get('traceparent');
+
+        // W3C traceparent: 00-<32 hex trace-id>-<16 hex span-id>-<2 hex flags>
+        if (null !== $traceparent
+            && 1 === preg_match('/^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/', $traceparent, $m)
+        ) {
+            $record->extra['trace_id'] = $m[1];
+            $record->extra['span_id'] = $m[2];
+        }
+
+        return $record;
+    }
+}

--- a/tests/Logger/EventSubscriber/AuthLoggingSubscriberTest.php
+++ b/tests/Logger/EventSubscriber/AuthLoggingSubscriberTest.php
@@ -5,19 +5,92 @@ declare(strict_types=1);
 namespace App\Tests\Logger\EventSubscriber;
 
 use App\Logger\EventSubscriber\AuthLoggingSubscriber;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTExpiredEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTFailureEventInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent;
 use Monolog\Handler\TestHandler;
 use Monolog\Level;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 
 class AuthLoggingSubscriberTest extends TestCase
 {
+    public function testLoginSuccessEmitsInfoWithIdentifierFirewallAndAuthenticator(): void
+    {
+        $handler = new TestHandler();
+        $subscriber = new AuthLoggingSubscriber(new Logger('auth', [$handler]));
+
+        $user = $this->createMock(UserInterface::class);
+        $user->method('getUserIdentifier')->willReturn('editor@example.com');
+        $authenticator = $this->createMock(AuthenticatorInterface::class);
+
+        $event = new LoginSuccessEvent(
+            $authenticator,
+            new SelfValidatingPassport(new UserBadge('editor@example.com', fn () => $user)),
+            $this->createMock(TokenInterface::class),
+            Request::create('/v2/authentication/token', Request::METHOD_POST),
+            null,
+            'main',
+        );
+
+        $subscriber->onLoginSuccess($event);
+
+        $this->assertTrue($handler->hasInfoRecords());
+        $record = $handler->getRecords()[0];
+        $this->assertSame('auth.login_success', $record->context['event']);
+        $this->assertSame('editor@example.com', $record->context['user_identifier']);
+        $this->assertSame('main', $record->context['firewall']);
+        $this->assertSame($authenticator::class, $record->context['authenticator']);
+    }
+
+    /**
+     * The `reason` string is what operators key dashboards on, and the three
+     * concrete Lexik events all share JWTFailureEventInterface — an easy arm to
+     * mis-wire — so pin each mapping, including the `unknown` default.
+     */
+    public function testJwtFailureMapsEachEventTypeToReason(): void
+    {
+        $exception = new AuthenticationException('nope');
+        $cases = [
+            'invalid' => new JWTInvalidEvent($exception, null),
+            'expired' => new JWTExpiredEvent($exception, null),
+            'not_found' => new JWTNotFoundEvent($exception, null),
+            'unknown' => $this->unknownFailureEvent($exception),
+        ];
+
+        foreach ($cases as $expectedReason => $event) {
+            $handler = new TestHandler();
+            $subscriber = new AuthLoggingSubscriber(new Logger('auth', [$handler]));
+
+            $subscriber->onJwtFailure($event);
+
+            $this->assertTrue($handler->hasWarningRecords(), "reason=$expectedReason");
+            $record = $handler->getRecords()[0];
+            $this->assertSame('auth.jwt_failure', $record->context['event']);
+            $this->assertSame($expectedReason, $record->context['reason']);
+        }
+    }
+
+    private function unknownFailureEvent(AuthenticationException $exception): JWTFailureEventInterface
+    {
+        $event = $this->createMock(JWTFailureEventInterface::class);
+        $event->method('getException')->willReturn($exception);
+
+        return $event;
+    }
+
     public function testLoginFailureEmitsAuthWarningWithoutCredentials(): void
     {
         $handler = new TestHandler();

--- a/tests/Logger/EventSubscriber/AuthLoggingSubscriberTest.php
+++ b/tests/Logger/EventSubscriber/AuthLoggingSubscriberTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Logger\EventSubscriber;
+
+use App\Logger\EventSubscriber\AuthLoggingSubscriber;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+class AuthLoggingSubscriberTest extends TestCase
+{
+    public function testLoginFailureEmitsAuthWarningWithoutCredentials(): void
+    {
+        $handler = new TestHandler();
+        $subscriber = new AuthLoggingSubscriber(new Logger('auth', [$handler]));
+
+        $event = new LoginFailureEvent(
+            new BadCredentialsException('Invalid credentials.'),
+            $this->createMock(AuthenticatorInterface::class),
+            Request::create('/v2/authentication/token', Request::METHOD_POST, [], [], [], [], '{"password":"s3cr3t"}'),
+            null,
+            'main',
+        );
+
+        $subscriber->onLoginFailure($event);
+
+        $this->assertTrue($handler->hasWarningRecords());
+        $records = $handler->getRecords();
+        $this->assertCount(1, $records);
+        $record = $records[0];
+        $this->assertSame(Level::Warning, $record->level);
+        $this->assertSame('auth.login_failure', $record->context['event']);
+        $this->assertSame('main', $record->context['firewall']);
+
+        // No credential material anywhere in the serialised record.
+        $this->assertStringNotContainsStringIgnoringCase('s3cr3t', json_encode($record->toArray(), JSON_THROW_ON_ERROR));
+    }
+
+    public function testLogoutEmitsInfoWithUserIdentifier(): void
+    {
+        $handler = new TestHandler();
+        $subscriber = new AuthLoggingSubscriber(new Logger('auth', [$handler]));
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUserIdentifier')->willReturn('editor@example.com');
+
+        $subscriber->onLogout(new LogoutEvent(Request::create('/'), $token));
+
+        $this->assertTrue($handler->hasInfoRecords());
+        $record = $handler->getRecords()[0];
+        $this->assertSame('auth.logout', $record->context['event']);
+        $this->assertSame('editor@example.com', $record->context['user_identifier']);
+    }
+}

--- a/tests/Logger/EventSubscriber/RequestIdSubscriberTest.php
+++ b/tests/Logger/EventSubscriber/RequestIdSubscriberTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Logger\EventSubscriber;
+
+use App\Logger\EventSubscriber\RequestIdSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class RequestIdSubscriberTest extends TestCase
+{
+    private const HEADER = 'X-Request-Id';
+    private const ATTR = '_request_id';
+
+    public function testInboundHeaderIsAdoptedAndEchoedOnResponse(): void
+    {
+        $subscriber = new RequestIdSubscriber();
+        $request = Request::create('/');
+        $request->headers->set(self::HEADER, 'upstream-id-123');
+
+        $subscriber->onRequest($this->requestEvent($request));
+        $this->assertSame('upstream-id-123', $request->attributes->get(self::ATTR));
+
+        $response = new Response();
+        $subscriber->onResponse($this->responseEvent($request, $response));
+        $this->assertSame('upstream-id-123', $response->headers->get(self::HEADER));
+    }
+
+    public function testIdIsMintedWhenNoInboundHeaderAndEchoedOnResponse(): void
+    {
+        $subscriber = new RequestIdSubscriber();
+        $request = Request::create('/');
+
+        $subscriber->onRequest($this->requestEvent($request));
+        $minted = $request->attributes->get(self::ATTR);
+        $this->assertIsString($minted);
+        $this->assertNotSame('', $minted);
+
+        $response = new Response();
+        $subscriber->onResponse($this->responseEvent($request, $response));
+        $this->assertSame($minted, $response->headers->get(self::HEADER));
+    }
+
+    public function testEmptyInboundHeaderMintsAFreshId(): void
+    {
+        $subscriber = new RequestIdSubscriber();
+        $request = Request::create('/');
+        $request->headers->set(self::HEADER, '');
+
+        $subscriber->onRequest($this->requestEvent($request));
+
+        // `?:` treats the empty header as absent and mints a non-empty id.
+        $this->assertNotSame('', $request->attributes->get(self::ATTR));
+    }
+
+    public function testResponseHeaderIsNotOverwrittenWhenAlreadySet(): void
+    {
+        $subscriber = new RequestIdSubscriber();
+        $request = Request::create('/');
+        $request->attributes->set(self::ATTR, 'our-id');
+
+        $response = new Response();
+        $response->headers->set(self::HEADER, 'downstream-id');
+        $subscriber->onResponse($this->responseEvent($request, $response));
+
+        $this->assertSame('downstream-id', $response->headers->get(self::HEADER));
+    }
+
+    public function testSubRequestIsIgnored(): void
+    {
+        $subscriber = new RequestIdSubscriber();
+        $request = Request::create('/');
+
+        $subscriber->onRequest($this->requestEvent($request, HttpKernelInterface::SUB_REQUEST));
+        $this->assertNull($request->attributes->get(self::ATTR));
+
+        $request->attributes->set(self::ATTR, 'main-id');
+        $response = new Response();
+        $subscriber->onResponse($this->responseEvent($request, $response, HttpKernelInterface::SUB_REQUEST));
+        $this->assertFalse($response->headers->has(self::HEADER));
+    }
+
+    private function requestEvent(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST): RequestEvent
+    {
+        return new RequestEvent($this->createMock(HttpKernelInterface::class), $request, $type);
+    }
+
+    private function responseEvent(Request $request, Response $response, int $type = HttpKernelInterface::MAIN_REQUEST): ResponseEvent
+    {
+        return new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, $type, $response);
+    }
+}

--- a/tests/Logger/Processor/RequestContextProcessorTest.php
+++ b/tests/Logger/Processor/RequestContextProcessorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Logger\Processor;
+
+use App\Entity\ScreenUser;
+use App\Entity\Tenant;
+use App\Entity\Tenant\Screen;
+use App\Entity\User;
+use App\Logger\Processor\RequestContextProcessor;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Uid\Ulid;
+
+class RequestContextProcessorTest extends TestCase
+{
+    public function testNoRequestAndNoUserLeavesRecordUnenriched(): void
+    {
+        $processor = new RequestContextProcessor(new RequestStack(), $this->security(null));
+
+        $record = $processor($this->record());
+
+        $this->assertArrayNotHasKey('request_id', $record->extra);
+        $this->assertArrayNotHasKey('route', $record->extra);
+        $this->assertArrayNotHasKey('user_id', $record->extra);
+        $this->assertArrayNotHasKey('screen_id', $record->extra);
+    }
+
+    public function testRequestContextLogsPathTemplateNotConcreteId(): void
+    {
+        // A concrete item URL carrying a ULID, with the matched route params
+        // Symfony sets on the request after routing.
+        $request = Request::create('/v2/screens/01HXYZ1234567890ABCDEFGHJK', Request::METHOD_GET);
+        $request->attributes->set('_request_id', 'abc123def4567890abc123def4567890');
+        $request->attributes->set('_route', 'screen_item');
+        $request->attributes->set('_route_params', ['id' => '01HXYZ1234567890ABCDEFGHJK']);
+        $stack = new RequestStack();
+        $stack->push($request);
+
+        $processor = new RequestContextProcessor($stack, $this->security(null));
+
+        $record = $processor($this->record());
+
+        // 32-char hex request id accepted verbatim — no reformatting/rejection.
+        $this->assertSame('abc123def4567890abc123def4567890', $record->extra['request_id']);
+        // Path template, id-free — the concrete ULID is substituted back to {id}.
+        $this->assertSame('/v2/screens/{id}', $record->extra['route']);
+        $this->assertSame('GET', $record->extra['method']);
+    }
+
+    public function testRouteIsUnsetWhenNoRouteMatched(): void
+    {
+        $request = Request::create('/v2/unmatched', Request::METHOD_GET);
+        $stack = new RequestStack();
+        $stack->push($request);
+
+        $processor = new RequestContextProcessor($stack, $this->security(null));
+
+        $record = $processor($this->record());
+
+        // No `_route` attribute => no template; the id-bearing path is not logged here.
+        $this->assertArrayNotHasKey('route', $record->extra);
+        $this->assertSame('GET', $record->extra['method']);
+    }
+
+    public function testScreenUserPopulatesScreenIdAndTenantNotUserId(): void
+    {
+        $tenant = $this->createMock(Tenant::class);
+        $tenant->method('getTenantKey')->willReturn('Example1');
+
+        $screen = $this->createMock(Screen::class);
+        $screen->method('getId')->willReturn(new Ulid());
+
+        $user = $this->createMock(ScreenUser::class);
+        $user->method('getScreen')->willReturn($screen);
+        $user->method('getActiveTenant')->willReturn($tenant);
+
+        $processor = new RequestContextProcessor(new RequestStack(), $this->security($user));
+
+        $record = $processor($this->record());
+
+        $this->assertArrayHasKey('screen_id', $record->extra);
+        $this->assertArrayNotHasKey('user_id', $record->extra);
+        $this->assertSame('Example1', $record->extra['tenant_id']);
+    }
+
+    public function testBackOfficeUserPopulatesUserIdNotScreenId(): void
+    {
+        $tenant = $this->createMock(Tenant::class);
+        $tenant->method('getTenantKey')->willReturn('Example1');
+
+        $user = $this->createMock(User::class);
+        $user->method('getUserIdentifier')->willReturn('editor@example.com');
+        $user->method('getActiveTenant')->willReturn($tenant);
+
+        $processor = new RequestContextProcessor(new RequestStack(), $this->security($user));
+
+        $record = $processor($this->record());
+
+        $this->assertSame('editor@example.com', $record->extra['user_id']);
+        $this->assertArrayNotHasKey('screen_id', $record->extra);
+        $this->assertSame('Example1', $record->extra['tenant_id']);
+    }
+
+    public function testActiveTenantResolutionFailureDoesNotThrow(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getUserIdentifier')->willReturn('editor@example.com');
+        $user->method('getActiveTenant')->willThrowException(new \InvalidArgumentException('no tenant'));
+
+        $processor = new RequestContextProcessor(new RequestStack(), $this->security($user));
+
+        $record = $processor($this->record());
+
+        $this->assertSame('editor@example.com', $record->extra['user_id']);
+        $this->assertArrayNotHasKey('tenant_id', $record->extra);
+    }
+
+    private function record(): LogRecord
+    {
+        return new LogRecord(new \DateTimeImmutable('2026-06-02T00:00:00+00:00'), 'screen', Level::Info, 'test');
+    }
+
+    private function security(?object $user): Security
+    {
+        $security = $this->createMock(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        return $security;
+    }
+}

--- a/tests/Logger/Processor/TraceContextProcessorTest.php
+++ b/tests/Logger/Processor/TraceContextProcessorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Logger\Processor;
+
+use App\Logger\Processor\TraceContextProcessor;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class TraceContextProcessorTest extends TestCase
+{
+    public function testValidTraceparentYieldsTraceAndSpanIds(): void
+    {
+        $request = Request::create('/');
+        $request->headers->set('traceparent', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01');
+        $stack = new RequestStack();
+        $stack->push($request);
+
+        $record = (new TraceContextProcessor($stack))($this->record());
+
+        $this->assertSame('4bf92f3577b34da6a3ce929d0e0e4736', $record->extra['trace_id']);
+        $this->assertSame('00f067aa0ba902b7', $record->extra['span_id']);
+    }
+
+    public function testInvalidTraceparentLeavesFieldsUnset(): void
+    {
+        $request = Request::create('/');
+        $request->headers->set('traceparent', 'garbage');
+        $stack = new RequestStack();
+        $stack->push($request);
+
+        $record = (new TraceContextProcessor($stack))($this->record());
+
+        $this->assertArrayNotHasKey('trace_id', $record->extra);
+        $this->assertArrayNotHasKey('span_id', $record->extra);
+    }
+
+    public function testNoRequestLeavesFieldsUnset(): void
+    {
+        $record = (new TraceContextProcessor(new RequestStack()))($this->record());
+
+        $this->assertArrayNotHasKey('trace_id', $record->extra);
+        $this->assertArrayNotHasKey('span_id', $record->extra);
+    }
+
+    private function record(): LogRecord
+    {
+        return new LogRecord(new \DateTimeImmutable('2026-06-02T00:00:00+00:00'), 'outbound_http', Level::Info, 'test');
+    }
+}


### PR DESCRIPTION
## PR 1 of 4 — Structured logging

First of a four-PR series implementing structured, channel-split, context-rich logging (see `docs/adr/011-structured-logging.md`). Base branch: `release/3.0.0`.

### What this PR does

- **Channels** — declares per-domain Monolog channels (`auth`, `screen`, `media`, `feed`, `interactive`, `cache`) alongside `outbound_http` (the renamed `app_http` outbound-HTTP-client channel, see below).
- **Outbound-HTTP channel rename + native client silenced** — `app_http` → `outbound_http`; a `NullLogger` decorates Symfony's native `http_client` logger so `LoggingHttpClient` is the single, OTel-shaped source of outbound-HTTP logs (no duplicate request logging).
- **Per-channel prod handlers** — one always-on stderr handler per domain channel. A Monolog handler carries a single `level`, so per-channel thresholds need per-channel handlers. Each level is `LOG_LEVEL_<CHANNEL>` falling back to a global `LOG_LEVEL` (via the `app.log_level` parameter and the empty-safe `default:` env processor). `info` reproduces today's output, so this is additive.
- **Configurable destination** — all prod handlers (incl. `nested`/`outbound_http`) write to `LOG_PATH` (default `php://stderr`). Suits container stderr capture; bare-metal nginx + php-fpm operators can point it at a file (they own rotation/permissions). New `.env`: `LOG_PATH`, `LOG_LEVEL`, `LOG_LEVEL_<CHANNEL>` (empty = inherit).
- **`RequestContextProcessor`** — enriches every record with `request_id`, `route`, `method`, and identity (`user_id` XOR `screen_id`, `tenant_id`). No request-id format validation. Identity-resolution failures (no active tenant, unhydrated screen token, …) are caught so enrichment never breaks the request it is annotating.
- **`TraceContextProcessor`** — parses a W3C `traceparent` header into `trace_id` / `span_id`.
- **`RequestIdSubscriber`** — adopts the inbound `X-Request-Id` or mints one, echoes it on the response.
- **`AuthLoggingSubscriber`** — logs login/logout and JWT invalid/expired/not-found on the `auth` channel. Logging only — never token strings or credentials, and each handler is guarded so a logging failure can never break authentication.

> Field names here are interim (`request_id`, `route`, `method`, `user_id`, `screen_id`, `tenant_id`). The rename to OpenTelemetry semantic conventions lands in PR 2.

### Verification

- `composer code-analysis` — green (PHPStan level 6)
- `composer coding-standards-check` + env-coverage — green
- `composer test` — green (18 tests across both processors, the request-id subscriber, and the auth subscriber)
- `cache:clear --env=prod` — per-channel handlers + `LOG_LEVEL` fallback resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
