### PR TITLE
perf(opcache): tune production OPcache for the measured app footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Tuned OPcache in the production image: enabled Symfony class preloading
+  (`PHP_OPCACHE_PRELOAD=/app/config/preload.php`, relying on the entrypoint's `cache:warmup`), dumped
+  the compiled service container into a single file (`.container.dumper.inline_factories: true`),
+  raised the interned-strings buffer to 32 MB (the base-image default of 16 is too tight for
+  Symfony's class-name volume), and right-sized `PHP_OPCACHE_MAX_ACCELERATED_FILES` to `16229` — the
+  prime bucket above the ~8k PHP files the prod image actually ships (vendor `--no-dev` ≈ 7.5k + app
+  code + warmed `var/cache/prod`), replacing the previous `20000`, which OPcache silently rounded up
+  to `32531`.
 - Upgraded `itk-dev/openid-connect-bundle` to 5.0 (and `itk-dev/openid-connect` to 5.0). Migrated the
   OIDC exception catches in `AuthOidcController` and `AzureOidcAuthenticator` to the new
   `OpenIdConnectExceptionInterface` marker, since concrete exceptions no longer extend the deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
   prime bucket above the ~8k PHP files the prod image actually ships (vendor `--no-dev` ≈ 7.5k + app
   code + warmed `var/cache/prod`), replacing the previous `20000`, which OPcache silently rounded up
   to `32531`.
+- Added an OPcache introspection probe to the production image: `docker exec <container> opcache-status`
+  dumps the FPM pool's `opcache_get_status()` + `opcache_get_configuration()` as JSON. A minimal
+  FastCGI client (`cgi-fcgi`, ~100 KB) executes the read-only `bin/opcache-status.php` inside an FPM
+  worker — the only place the pool's OPcache shared memory is visible — instead of bundling the ~4 MB
+  cachetool phar. The script refuses web-served requests (`REMOTE_ADDR` guard), and nginx's
+  front-controller-only PHP routing never reaches it anyway.
 - Upgraded `itk-dev/openid-connect-bundle` to 5.0 (and `itk-dev/openid-connect` to 5.0). Migrated the
   OIDC exception catches in `AuthOidcController` and `AzureOidcAuthenticator` to the new
   `OpenIdConnectExceptionInterface` marker, since concrete exceptions no longer extend the deprecated

--- a/bin/opcache-status.php
+++ b/bin/opcache-status.php
@@ -1,0 +1,35 @@
+<?php
+
+// Read-only OPcache introspection, executed by an FPM worker so it sees the
+// pool's shared memory (CLI PHP has its own, separate OPcache). Invoked from
+// inside the container by the `opcache-status` wrapper (cgi-fcgi against the
+// pool); see infrastructure/display-api-service/opcache-status.
+//
+// Web-served requests are refused: a webserver always passes REMOTE_ADDR,
+// while the cgi-fcgi exec path does not, so a webserver (mis)configuration
+// routing this script can never expose it.
+
+declare(strict_types=1);
+
+if ('' !== ($_SERVER['REMOTE_ADDR'] ?? '')) {
+    http_response_code(404);
+    exit;
+}
+
+header('Content-Type: application/json');
+
+$status = function_exists('opcache_get_status') ? opcache_get_status(false) : false;
+
+if (false === $status) {
+    http_response_code(503);
+    echo json_encode(['error' => 'OPcache is not enabled for this FPM pool'], JSON_THROW_ON_ERROR);
+    exit;
+}
+
+echo json_encode(
+    [
+        'status' => $status,
+        'configuration' => opcache_get_configuration(),
+    ],
+    JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR
+);

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,11 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    # Dump the compiled service container into a single file with inlined
+    # factories instead of thousands of small files. Recommended for prod and
+    # required to get the most out of OPcache class preloading.
+    # https://symfony.com/doc/current/performance.html#dump-the-service-container-into-a-single-file
+    .container.dumper.inline_factories: true
 
 services:
     # default configuration for services in *this* file

--- a/infrastructure/display-api-service/Dockerfile
+++ b/infrastructure/display-api-service/Dockerfile
@@ -98,11 +98,25 @@ LABEL org.opencontainers.image.authors="ITK Dev <itkdev@ba.aarhus.dk>" \
       org.opencontainers.image.documentation="https://github.com/os2display/display-api-service#readme" \
       org.opencontainers.image.base.name="itkdev/php8.4-fpm:alpine"
 
+# OPcache values follow the Symfony performance checklist
+# (https://symfony.com/doc/current/performance.html): the prod image ships
+# ~8k PHP files (vendor --no-dev ≈ 7.5k + app code + warmed var/cache/prod),
+# so MAX_ACCELERATED_FILES=16229 (OPcache rounds up to primes from a fixed
+# table; 16229 is the bucket above 8k) leaves ~2x headroom; the 32 MB
+# interned-strings buffer covers Symfony's many fully-qualified class names
+# (the base image default of 16 is too tight). PRELOAD points at Symfony's
+# preload entry, which requires the warmed prod cache — docker-entrypoint.sh
+# runs cache:warmup before exec'ing php-fpm, so the generated
+# App_KernelProdContainer.preload.php exists by the time OPcache preloads.
+# PHP_OPCACHE_PRELOAD_USER is left at the base image's default (`deploy`),
+# which matches the user php-fpm's master runs as here (see USER below).
 ENV APP_ENV=prod \
     PHP_OPCACHE_ENABLED=1 \
     PHP_OPCACHE_VALIDATE_TIMESTAMPS=0 \
-    PHP_OPCACHE_MAX_ACCELERATED_FILES=20000 \
+    PHP_OPCACHE_MAX_ACCELERATED_FILES=16229 \
     PHP_OPCACHE_MEMORY_CONSUMPTION=256 \
+    PHP_OPCACHE_INTERNED_STRINGS_BUFFER=32 \
+    PHP_OPCACHE_PRELOAD=/app/config/preload.php \
     PHP_PM_TYPE="dynamic" \
     PHP_PM_MAX_CHILDREN="24" \
     PHP_PM_MAX_REQUESTS="0" \

--- a/infrastructure/display-api-service/Dockerfile
+++ b/infrastructure/display-api-service/Dockerfile
@@ -133,7 +133,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 # Prometheus exporter for php-fpm pool stats; scraped by ops monitoring.
 COPY --from=hipages/php-fpm_exporter:2.2.0 /php-fpm_exporter /usr/local/bin/php-fpm_exporter
 
-COPY --chmod=0755 docker-entrypoint.sh /usr/local/bin/
+# Minimal FastCGI client (~100 KB) so `opcache-status` can execute
+# bin/opcache-status.php inside an FPM worker — the only place the pool's
+# OPcache shared memory is visible (CLI PHP has its own). The lightweight
+# alternative to bundling the ~4 MB cachetool phar.
+RUN apk add --no-cache fcgi
+
+COPY --chmod=0755 docker-entrypoint.sh opcache-status /usr/local/bin/
 
 USER deploy
 

--- a/infrastructure/display-api-service/opcache-status
+++ b/infrastructure/display-api-service/opcache-status
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Dump the running FPM pool's OPcache status as JSON.
+#
+# CLI PHP cannot see the pool's shared memory, so bin/opcache-status.php must
+# execute inside an FPM worker; cgi-fcgi sends it there over FastCGI. The awk
+# filter strips the CGI response headers, leaving pure JSON on stdout.
+#
+# Usage (from the host): docker exec <container> opcache-status
+set -e
+
+SCRIPT_FILENAME=/app/bin/opcache-status.php \
+SCRIPT_NAME=/opcache-status.php \
+REQUEST_METHOD=GET \
+cgi-fcgi -bind -connect 127.0.0.1:9000 | awk 'body { print } /^\r?$/ { body = 1 }'


### PR DESCRIPTION
## Summary
Tunes the production image's OPcache configuration against the app's *measured* footprint instead of inherited base-image defaults — and adds a lightweight probe so the resulting cache behavior can actually be observed in production.

## Features Added
* **Class preloading**: `PHP_OPCACHE_PRELOAD=/app/config/preload.php` — the entrypoint's `cache:warmup` generates `App_KernelProdContainer.preload.php` before php-fpm starts, so the preload target exists at OPcache init. `PHP_OPCACHE_PRELOAD_USER` stays at the base image's `deploy`, matching the FPM master user.
* **Single-file container**: `.container.dumper.inline_factories: true` dumps the compiled service container as one file (3 files in `ContainerXXX/` instead of one factory file per service), per the Symfony performance checklist and a prerequisite for getting the most out of preloading.
* **Interned strings**: `PHP_OPCACHE_INTERNED_STRINGS_BUFFER=32` — the base image's 16 MB is too tight for Symfony's volume of fully-qualified class names.
* **Right-sized file count**: `PHP_OPCACHE_MAX_ACCELERATED_FILES=16229`. The prod image ships ~8k PHP files (vendor `--no-dev` ≈ 7.5k across 142 packages + ~290 app files + ~306 warmed `var/cache/prod` files), so the 16229 prime bucket leaves ~2× headroom. The previous `20000` was sized against a count that included dev dependencies — and OPcache silently rounded it up to `32531` anyway, since limits snap to a fixed prime table.
* **OPcache status probe**: `docker exec <container> opcache-status` dumps the FPM pool's `opcache_get_status()` + `opcache_get_configuration()` as JSON. A minimal FastCGI client (`cgi-fcgi`, ~100 KB Alpine package) executes the read-only `bin/opcache-status.php` inside an FPM worker — the only place the pool's OPcache shared memory is visible (CLI PHP has its own) — instead of bundling the ~4 MB cachetool phar. The script refuses web-served requests (`REMOTE_ADDR` guard), and nginx's front-controller-only PHP routing 404s any non-`index.php` script anyway.

## Files Changed
* `infrastructure/display-api-service/Dockerfile` — OPcache env vars + sizing rationale comment; `fcgi` package + `opcache-status` wrapper install
* `infrastructure/display-api-service/opcache-status` (new) — shell wrapper: cgi-fcgi call + CGI-header strip
* `bin/opcache-status.php` (new) — read-only status script executed in an FPM worker
* `config/services.yaml` — `.container.dumper.inline_factories: true` parameter
* `CHANGELOG.md` — entries under `[Unreleased]`

## Test Plan
* CI image build succeeds (preload path resolves only at container start, not build, so the image build is unaffected).
* Start the built image; verify php-fpm boots cleanly (a broken preload script is fatal at startup, so a clean boot proves preloading works).
* In the running container, verify settings took effect: `php-fpm -i | grep -E 'opcache.(preload|max_accelerated_files|interned_strings_buffer)'` → `16229`, `32`, `/app/config/preload.php`.
* `docker exec <container> opcache-status` returns JSON with `opcache_enabled: true`; `num_cached_keys` sits well below `max_cached_keys=16229` and `oom_restarts`/`hash_restarts` are 0. *(Verified in the dev stack: the FastCGI round-trip returns pool status JSON, and a request carrying `REMOTE_ADDR` gets `404`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)