### PR TITLE
chore(phpstan): require comments on inline @phpstan-ignore annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Enabled PHPStan's `reportIgnoresWithoutComments`: inline `@phpstan-ignore` annotations must
+  carry a comment explaining the suppression.
+
 ## [3.0.0-rc4] - 2026-06-04
 
 - Tuned OPcache in the production image: enabled Symfony class preloading, inlined container

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -3,6 +3,8 @@ includes:
 
 parameters:
     level: 6
+    # Inline `@phpstan-ignore` annotations must carry a `(comment)` explaining the suppression.
+    reportIgnoresWithoutComments: true
     paths:
         - src/
         - migrations/


### PR DESCRIPTION
## Summary
Enables PHPStan's `reportIgnoresWithoutComments` parameter so every inline `@phpstan-ignore` annotation must carry a `(comment)` explaining the suppression. Adopts the convention already in place in [itk-dev/openid-connect-bundle](https://github.com/itk-dev/openid-connect-bundle/blob/develop/phpstan.neon).

## Features Added
* Inline PHPStan suppressions now fail analysis unless written as `// @phpstan-ignore identifier (reason)`.
* Zero-cost adoption: no inline `@phpstan-ignore` annotations exist in `src/` or `migrations/` today, so this purely enforces discipline on future suppressions. The generated `phpstan-baseline.neon` is unaffected.

## Files Changed
* `phpstan.dist.neon` - added `reportIgnoresWithoutComments: true` with explanatory comment
* `CHANGELOG.md` - entry under `[Unreleased]`

## Test Plan
* `task code-analysis` → `[OK] No errors` (verified locally)
* To see the gate in action: add a bare `// @phpstan-ignore something` to any file under `src/` and observe PHPStan fail with a missing-comment error

🤖 Generated with [Claude Code](https://claude.com/claude-code)