### PR TITLE
fix: correct inverted user-type guard in UserService::activateExternalUser()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed inverted user-type guard in `UserService::activateExternalUser()`: the "user is not of
+  external type" check could never trigger due to a stray negation (`=== !$user->getUserType()`).
+  The endpoint was still protected by `ExternalUserAuthenticator`, so this restores the intended
+  defense-in-depth at the service layer. Added unit tests.
 - Enabled PHPStan's `reportIgnoresWithoutComments`: inline `@phpstan-ignore` annotations must
   carry a comment explaining the suppression.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2827,18 +2827,6 @@ parameters:
 			path: src/Service/TenantFactory.php
 
 		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: src/Service/UserService.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between App\\Enum\\UserTypeEnum\:\:OIDC_EXTERNAL and false will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/Service/UserService.php
-
-		-
 			message: '#^Class App\\State\\AbstractProcessor implements generic interface ApiPlatform\\State\\ProcessorInterface but does not specify its types\: T1, T2$#'
 			identifier: missingType.generics
 			count: 1

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -71,7 +71,7 @@ class UserService
         $user = $this->security->getUser();
 
         // Make sure user is an external user.
-        if (UserTypeEnum::OIDC_EXTERNAL === !$user->getUserType()) {
+        if (UserTypeEnum::OIDC_EXTERNAL !== $user->getUserType()) {
             throw new BadRequestException('User is not of external type.');
         }
 

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Enum\UserTypeEnum;
+use App\Exceptions\BadRequestException;
+use App\Exceptions\NotFoundException;
+use App\Repository\UserActivationCodeRepository;
+use App\Repository\UserRepository;
+use App\Repository\UserRoleTenantRepository;
+use App\Service\UserService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Security;
+
+class UserServiceTest extends TestCase
+{
+    public function testActivateExternalUserThrowsForNonExternalUser(): void
+    {
+        $user = new User();
+        $user->setUserType(UserTypeEnum::OIDC_INTERNAL);
+
+        $userService = $this->createUserService($user);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('User is not of external type.');
+
+        $userService->activateExternalUser('SOMECODE');
+    }
+
+    public function testActivateExternalUserThrowsForUnknownCode(): void
+    {
+        $user = new User();
+        $user->setUserType(UserTypeEnum::OIDC_EXTERNAL);
+
+        $userService = $this->createUserService($user);
+
+        $this->expectException(NotFoundException::class);
+
+        $userService->activateExternalUser('UNKNOWNCODE');
+    }
+
+    private function createUserService(User $user): UserService
+    {
+        $security = $this->createMock(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $activationCodeRepository = $this->createMock(UserActivationCodeRepository::class);
+        $activationCodeRepository->method('findOneBy')->willReturn(null);
+
+        return new UserService(
+            $activationCodeRepository,
+            $this->createMock(EntityManagerInterface::class),
+            $security,
+            'hash-salt',
+            $this->createMock(UserRoleTenantRepository::class),
+            $this->createMock(UserRepository::class),
+            'P2D',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Fixes an inverted type guard in `UserService::activateExternalUser()` found while reviewing the PHPStan baseline (`identical.alwaysFalse` / `booleanNot.alwaysFalse`).

The guard "Make sure user is an external user" compared the enum against a negated method call:

```php
if (UserTypeEnum::OIDC_EXTERNAL === !$user->getUserType()) {
```

`!$user->getUserType()` coerces the enum to `false`, so the comparison is always false and the check never threw. Fixed to `!==` against the enum value, matching the equivalent guard in `removeUserFromCurrentTenant()`.

**Impact:** the `/v2/user-activation-codes/activate` route is gated by `ExternalUserAuthenticator`, which already rejects non-external users at the firewall — so this was dead defense-in-depth rather than an exploitable hole. This PR restores the intended service-layer check.

## Files Changed
* `src/Service/UserService.php` — `=== !` → `!==` in the user-type guard
* `tests/Service/UserServiceTest.php` (new) — unit tests: non-external user → `BadRequestException` (fails against the old code, which fell through to `NotFoundException`); external user with unknown code → `NotFoundException`
* `phpstan-baseline.neon` — regenerated via `task phpstan:generate-baseline`; drops the two stale entries
* `CHANGELOG.md` — entry under \[Unreleased\]

## Test Plan
* `task test:api -- --filter UserServiceTest` — OK (2 tests, 3 assertions)
* `task test:api -- --filter UserTest` — external user activation flow still green (5 tests, 62 assertions)
* `task code-analysis` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)