### PR TITLE
ci(playwright): run E2E in parallel and drop redundant browser install

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -56,14 +56,18 @@ jobs:
           docker compose run --rm node npm run build
 
       - name: Run playwright
-        env:
-          CI: "true"
+        # `-e CI=true` propagates CI *into* the container — `docker compose run`
+        # does not forward host env by default, so without it playwright.config.ts
+        # sees no CI and falls back to its defaults (50% of cores ≈ 2 workers,
+        # retries 0). The explicit flag is what actually enables workers: 3 and
+        # retries: 2 on the runner.
+        #
         # The mcr.microsoft.com/playwright image already bundles the browsers for
         # its version, kept in lockstep with @playwright/test in package.json, so
         # `playwright install --with-deps` only re-runs apt for libraries that are
         # already present. Run the tests directly.
         run: |
-          docker compose run --rm playwright npx playwright test
+          docker compose run --rm -e CI=true playwright npx playwright test
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -42,6 +42,15 @@ jobs:
       - name: Setup network
         run: docker network create frontend
 
+      - name: Pull container images
+        # Pull all images this job uses up front, in parallel (compose pulls
+        # services concurrently). Otherwise each image is pulled on demand inside
+        # the first step that uses it — serially across steps (~90s total:
+        # mariadb+phpfpm in Composer install, node in Build assets,
+        # nginx+playwright in Run playwright). Pulling concurrently overlaps the
+        # smaller images under the large playwright pull.
+        run: docker compose pull --quiet phpfpm node playwright nginx mariadb
+
       - name: Composer install
         run: |
           docker compose run --rm phpfpm composer install

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -58,8 +58,11 @@ jobs:
       - name: Run playwright
         env:
           CI: "true"
+        # The mcr.microsoft.com/playwright image already bundles the browsers for
+        # its version, kept in lockstep with @playwright/test in package.json, so
+        # `playwright install --with-deps` only re-runs apt for libraries that are
+        # already present. Run the tests directly.
         run: |
-          docker compose run --rm playwright npx playwright install --with-deps
           docker compose run --rm playwright npx playwright test
 
       - uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Sped up the Playwright CI job: it now runs in parallel (3 workers, sized to the 4-vCPU public
-  GitHub runner) instead of a single worker, added `ipc: host` to the `playwright` Compose
-  service so parallel Chromium does not exhaust Docker's default 64 MB `/dev/shm`, and dropped
-  the redundant `playwright install --with-deps` step (the pinned Playwright image already ships
-  the matching browsers).
+  GitHub runner) instead of the default 2, added `ipc: host` to the `playwright` Compose
+  service so parallel Chromium does not exhaust Docker's default 64 MB `/dev/shm`, pulls the
+  container images once up front in parallel instead of on demand serially across steps
+  (~90s of pulls overlapped), and dropped the redundant `playwright install --with-deps` step
+  (the pinned Playwright image already ships the matching browsers).
 - Removed a dead statement in `MediaRepository::getPaginator()` that referenced the undefined
   variables `$page` and `$itemsPerPage`; the computed value was never used.
 - Fixed inverted user-type guard in `UserService::activateExternalUser()`: the "user is not of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Sped up the Playwright CI job: it now runs in parallel (3 workers, sized to the 4-vCPU public
+  GitHub runner) instead of a single worker, added `ipc: host` to the `playwright` Compose
+  service so parallel Chromium does not exhaust Docker's default 64 MB `/dev/shm`, and dropped
+  the redundant `playwright install --with-deps` step (the pinned Playwright image already ships
+  the matching browsers).
 - Removed a dead statement in `MediaRepository::getPaginator()` that referenced the undefined
   variables `$page` and `$itemsPerPage`; the computed value was never used.
 - Fixed inverted user-type guard in `UserService::activateExternalUser()`: the "user is not of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,10 @@ services:
     # https://playwright.dev/docs/docker
     # Version should match the one in `package.json`.
     image: mcr.microsoft.com/playwright:v1.57.0
+    # Chromium needs more than Docker's default 64 MB /dev/shm once tests run in
+    # parallel; sharing the host IPC namespace avoids renderer crashes
+    # ("Target closed"). See the Playwright Docker docs.
+    ipc: host
     networks:
       - app
     depends_on:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,8 +20,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* CI runs on a 4-vCPU GitHub-hosted runner (public repo); use 3 workers and
+   * leave one core for the browser/system. Tests mock every network call per
+   * page (see assets/tests/**\/test-helper.js), so they are isolated and safe
+   * to run in parallel. Locally, Playwright's default (50% of cores) applies. */
+  workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   // Open never added to avoid the CI pipeline to get stuck in a html-reporter-mode.
   reporter: [['html', { open: 'never' }]],


### PR DESCRIPTION
## What

Speeds up the Playwright CI job — the slowest check on every PR — with four changes:

1. **3 parallel workers on CI** (`playwright.config.ts`, was the default 2). Sized to the 4-vCPU public-repo runner (one core for the browser/system).
2. **Propagate `CI` into the container** (`-e CI=true` on `docker compose run`). `docker compose run` doesn't forward host env, so `process.env.CI` was undefined inside the container and `workers`/`retries` silently fell back to defaults — this flag is what actually enables `workers: 3` and `retries: 2`.
3. **`ipc: host`** on the `playwright` Compose service so parallel Chromium doesn't exhaust Docker's default 64 MB `/dev/shm` ("Target closed" crashes).
4. **Pre-pull images in parallel** — a single up-front `docker compose pull` instead of on-demand pulls scattered serially across steps.
5. **Drop `playwright install --with-deps`** — the pinned `mcr.microsoft.com/playwright:v1.57.0` image already ships the matching browsers.

## Measured before / after (total Playwright job)

| Configuration | Total |
|---|---|
| Baseline (`release/3.0.0`) | ~257s (270/250/252) |
| 3 workers + dropped install | 225s |
| **+ parallel pre-pull (final)** | **195s** |

**~257s → 195s, ≈ 1.32× faster end-to-end**, suite green with **3 workers** and **0 flaky** on CI.

Step-level (baseline → final): a new **35s** parallel pull replaces ~88s of serial on-demand pulls; Composer install 38s→11s, Build assets ~40s→21s, Run playwright 168s→107s.

## Why it's safe

Every test mocks all network traffic per page (`assets/tests/**/test-helper.js`); no shared mutable backend state — `workers: 1`/default was a pure throttle, not isolation. `ipc: host` verified working (`/dev/shm` = 12G, zero "Target closed" on CI).

## Note on the original estimate

The plan predicted ~2.5–3×, computed against a **1-worker** baseline — but CI was already running **2 workers** (Playwright's default) because `CI` never reached the container. The real, measured win is ~1.3×; the parallel pre-pull contributed roughly half of it.

## Non-goals (deferred)

`retries` kept at 2; no cross-runner sharding; no Playwright version bump; build/cache steps untouched. (A parallel pre-pull could also shave ~13–20s off the `phpunit`/`doctrine`/`apispec` jobs, which pull phpfpm+mariadb — a possible follow-up; the `--no-deps` jobs wouldn't benefit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)