### PR TITLE
ci: pre-pull phpfpm+mariadb images in PHPUnit/Doctrine/API-spec jobs

### DIFF
--- a/.github/workflows/apispec.yaml
+++ b/.github/workflows/apispec.yaml
@@ -50,6 +50,12 @@ jobs:
       - name: Setup network
         run: docker network create frontend
 
+      - name: Pull container images
+        # Pull phpfpm and mariadb up front, in parallel, instead of on demand:
+        # `docker compose run phpfpm` starts mariadb (depends_on), so otherwise
+        # the two images are pulled serially inside the first step (~30s).
+        run: docker compose pull --quiet phpfpm mariadb
+
       - name: Install Dependencies
         run: docker compose run --rm phpfpm composer install
 

--- a/.github/workflows/doctrine.yaml
+++ b/.github/workflows/doctrine.yaml
@@ -77,6 +77,13 @@ jobs:
       - name: Setup network
         run: docker network create frontend
 
+      - name: Pull container images
+        # Pull phpfpm and mariadb up front, in parallel, instead of on demand:
+        # `docker compose run phpfpm` starts mariadb (depends_on), so otherwise
+        # the two images are pulled serially inside the first step (~30s). The
+        # postgres job below builds phpfpm locally instead, so it is not pre-pulled.
+        run: docker compose pull --quiet phpfpm mariadb
+
       - name: "[prod] Composer install"
         run: docker compose run --rm -e APP_ENV=prod phpfpm composer install --no-dev -o
 

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -50,6 +50,12 @@ jobs:
       - name: Setup network
         run: docker network create frontend
 
+      - name: Pull container images
+        # Pull phpfpm and mariadb up front, in parallel, instead of on demand:
+        # `docker compose run phpfpm` starts mariadb (depends_on), so otherwise
+        # the two images are pulled serially inside the first step (~30s).
+        run: docker compose pull --quiet phpfpm mariadb
+
       - name: Install Dependencies
         run: docker compose run --rm phpfpm composer install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
   container images once up front in parallel instead of on demand serially across steps
   (~90s of pulls overlapped), and dropped the redundant `playwright install --with-deps` step
   (the pinned Playwright image already ships the matching browsers).
+- Pre-pull the `phpfpm` and `mariadb` images in parallel in the PHPUnit, Doctrine and API-spec
+  CI jobs (running `phpfpm` starts `mariadb` via `depends_on`, so the two were otherwise pulled
+  serially on demand). The Doctrine Postgres job is unaffected — it builds `phpfpm` locally.
 - Removed a dead statement in `MediaRepository::getPaginator()` that referenced the undefined
   variables `$page` and `$itemsPerPage`; the computed value was never used.
 - Fixed inverted user-type guard in `UserService::activateExternalUser()`: the "user is not of


### PR DESCRIPTION
Follow-up to #488 (Playwright parallel pre-pull), applying the same idea to the other jobs that pull more than one image.

## Why
`PHPUnit`, `Doctrine` (MariaDB matrix) and `API-spec` run `docker compose run phpfpm …` **without `--no-deps`**, so `phpfpm` starting also starts `mariadb` (its `depends_on`). The two images were therefore pulled **serially, on demand** inside the first step (~30s measured: mariadb ~13s + phpfpm ~20s). A single up-front `docker compose pull --quiet phpfpm mariadb` pulls them concurrently → ~13s saved per job.

## Scope
- **PHPUnit** (×2 MariaDB matrix), **Doctrine** (×2 MariaDB matrix), **API-spec** (spec-export job): added a parallel pre-pull step.
- **Excluded — Doctrine Postgres job**: it *builds* `phpfpm` locally (`pdo_pgsql`) rather than pulling, so there's no parallel pull to gain.
- **Not touched** — the `--no-deps` jobs (`phpstan`, `rector`, `php-cs-fixer`, `twig`, `composer`) and single-image jobs (`vitest`, `markdown`): they pull one image, so parallelizing does nothing.

Per-PR cumulative saving across the matrix jobs; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)