### PR TITLE
fix(api): surface server-side outages (DB down, unusable JWT keys) as 503 — never a false 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Hardened database-outage handling: database connectivity failures (Doctrine DBAL
+  `ConnectionException`) now surface as `503 Service Unavailable` with a `Retry-After` header
+  instead of a generic 500 — and never as a false `401` — so API clients (e.g. the screen client)
+  can tell a temporary outage from an authentication failure and avoid logging out.
+
 ## [3.0.0-rc5] - 2026-06-10
 
 - Added structured, channel-split application logging (ADR 011): per-domain Monolog channels with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Hardened database-outage handling: database connectivity failures (Doctrine DBAL
-  `ConnectionException`) now surface as `503 Service Unavailable` with a `Retry-After` header
-  instead of a generic 500 — and never as a false `401` — so API clients (e.g. the screen client)
-  can tell a temporary outage from an authentication failure and avoid logging out.
+- Hardened server-side outage handling so API clients (e.g. the screen client) can tell a
+  temporary outage from an authentication failure and avoid logging out:
+  - Database connectivity failures (Doctrine DBAL `ConnectionException`) now surface as
+    `503 Service Unavailable` with a `Retry-After` header instead of a generic 500.
+  - Missing/unusable JWT signing keys (e.g. key files lost in a deployment) now surface as
+    `503 Service Unavailable` with `Retry-After` instead of a false `401 Invalid JWT Token`
+    on token validation and a generic 500 on token issuing/refresh.
 
 ## [3.0.0-rc5] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
   - Missing/unusable JWT signing keys (e.g. key files lost in a deployment) now surface as
     `503 Service Unavailable` with `Retry-After` instead of a false `401 Invalid JWT Token`
     on token validation and a generic 500 on token issuing/refresh.
+  - Each reclassification is logged per ADR 011: `db.unavailable` (`database` channel,
+    `error`) and `auth.jwt_key_unusable` (`auth` channel, `critical`). See `docs/logging.md`.
 
 ## [3.0.0-rc5] - 2026-06-10
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -123,6 +123,16 @@ services:
         arguments:
             $feedLogger: '@monolog.logger.feed'
 
+    # Answers 503 (instead of a generic 500 / false 401) on server-side
+    # outages; logs the reclassification on the matching channel.
+    App\EventSubscriber\DatabaseUnavailableExceptionSubscriber:
+        arguments:
+            $databaseLogger: '@monolog.logger.database'
+
+    App\EventSubscriber\JwtKeyMisconfigurationSubscriber:
+        arguments:
+            $authLogger: '@monolog.logger.auth'
+
     # Logs DB connection-establishment failures on the `database` channel.
     # The explicit doctrine.middleware tag is required: doctrine-bundle collects
     # tagged services in MiddlewaresPass; implementing the interface is not enough.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -171,3 +171,14 @@ Connection **pressure / unreachability** codes (`1040`, `1203`, `1226`, `2002`, 
 `2005`) are logged at `critical`; other connect failures (e.g. a `1045` credential error)
 at `error`. Both levels emit regardless of `LOG_LEVEL_DATABASE`, which only gates
 lower-severity `database`-channel records. Mid-query drops (`2006`/`2013`) are out of scope.
+
+## 503 Service Unavailable hardening
+
+Two subscribers reclassify server-side outages as `503 Service Unavailable` (with a
+`Retry-After` header) so clients — the screen client in particular — do not mistake an
+outage for an authentication failure and log out. Each reclassification emits a record:
+
+| Event | Channel | Level | When |
+|---|---|---|---|
+| `db.unavailable` | `database` | `error` | A request failed on a DBAL `ConnectionException` and was answered 503 (`DatabaseUnavailableExceptionSubscriber`). The underlying connect failure is additionally logged by the middleware above. |
+| `auth.jwt_key_unusable` | `auth` | `critical` | The configured JWT keys cannot be loaded/parsed (`JwtKeyMisconfigurationSubscriber`). Token validation answered 503 instead of a false 401 (`operation: validate`), or token signing on login/refresh answered 503 instead of a 500 (`operation: sign`). Critical because the authentication subsystem is down for every client. |

--- a/src/EventSubscriber/DatabaseUnavailableExceptionSubscriber.php
+++ b/src/EventSubscriber/DatabaseUnavailableExceptionSubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventSubscriber;
 
 use Doctrine\DBAL\Exception\ConnectionException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
@@ -18,10 +19,18 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * failure, making clients (e.g. the screen client) discard their tokens and
  * log out. A 503 with a Retry-After header tells clients the outage is
  * temporary: retry later, do not re-authenticate.
+ *
+ * Logs on the `database` channel (ADR 011). Connection-establishment
+ * failures themselves are logged at `critical` by ConnectionErrorMiddleware;
+ * the record here adds that a request was answered 503 because of one.
  */
 class DatabaseUnavailableExceptionSubscriber implements EventSubscriberInterface
 {
     final public const int RETRY_AFTER_SECONDS = 10;
+
+    public function __construct(
+        private readonly LoggerInterface $databaseLogger,
+    ) {}
 
     public static function getSubscribedEvents(): array
     {
@@ -42,6 +51,11 @@ class DatabaseUnavailableExceptionSubscriber implements EventSubscriberInterface
         // lost connections (ConnectionLost) and refused credentials.
         for ($e = $throwable; null !== $e; $e = $e->getPrevious()) {
             if ($e instanceof ConnectionException) {
+                $this->databaseLogger->error('Answering 503 Service Unavailable because the database is unavailable', [
+                    'event' => 'db.unavailable',
+                    'exception' => $throwable,
+                ]);
+
                 $event->setThrowable(new ServiceUnavailableHttpException(
                     self::RETRY_AFTER_SECONDS,
                     'Service temporarily unavailable. Please try again later.',

--- a/src/EventSubscriber/DatabaseUnavailableExceptionSubscriber.php
+++ b/src/EventSubscriber/DatabaseUnavailableExceptionSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Doctrine\DBAL\Exception\ConnectionException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Surfaces database connectivity failures as "503 Service Unavailable".
+ *
+ * Without this, an unreachable database surfaces as a generic 500 — and in
+ * the authentication flows it risks being mistaken for an authentication
+ * failure, making clients (e.g. the screen client) discard their tokens and
+ * log out. A 503 with a Retry-After header tells clients the outage is
+ * temporary: retry later, do not re-authenticate.
+ */
+class DatabaseUnavailableExceptionSubscriber implements EventSubscriberInterface
+{
+    final public const int RETRY_AFTER_SECONDS = 10;
+
+    public static function getSubscribedEvents(): array
+    {
+        // Positive priority so this runs before the framework's exception
+        // listeners (Symfony's ErrorListener and API Platform's exception
+        // listener) render a response from the original throwable.
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException', 50],
+        ];
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $throwable = $event->getThrowable();
+
+        // The connection failure may be wrapped by other layers, so walk the
+        // exception chain. ConnectionException covers failure to connect,
+        // lost connections (ConnectionLost) and refused credentials.
+        for ($e = $throwable; null !== $e; $e = $e->getPrevious()) {
+            if ($e instanceof ConnectionException) {
+                $event->setThrowable(new ServiceUnavailableHttpException(
+                    self::RETRY_AFTER_SECONDS,
+                    'Service temporarily unavailable. Please try again later.',
+                    $throwable,
+                ));
+
+                return;
+            }
+        }
+    }
+}

--- a/src/EventSubscriber/JwtKeyMisconfigurationSubscriber.php
+++ b/src/EventSubscriber/JwtKeyMisconfigurationSubscriber.php
@@ -9,6 +9,7 @@ use Lcobucci\JWT\Signer\InvalidKeyProvided;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,10 +36,17 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *   Lexik's JWT_INVALID event.
  * - Token issuing (login, refresh): signing failures escape as uncaught
  *   JWTEncodeFailureException, handled on kernel.exception.
+ *
+ * Logs at `critical` on the `auth` channel (ADR 011): with unusable keys the
+ * authentication subsystem is down for every client.
  */
 class JwtKeyMisconfigurationSubscriber implements EventSubscriberInterface
 {
     final public const int RETRY_AFTER_SECONDS = 10;
+
+    public function __construct(
+        private readonly LoggerInterface $authLogger,
+    ) {}
 
     public static function getSubscribedEvents(): array
     {
@@ -58,6 +66,12 @@ class JwtKeyMisconfigurationSubscriber implements EventSubscriberInterface
         // loaded at all marks the service as unable to validate any token.
         for ($e = $event->getException(); null !== $e; $e = $e->getPrevious()) {
             if ($e instanceof InvalidKeyProvided || $e instanceof CannotSignPayload) {
+                $this->authLogger->critical('JWT keys are unusable, answering 503 instead of 401 on token validation', [
+                    'event' => 'auth.jwt_key_unusable',
+                    'operation' => 'validate',
+                    'exception' => $event->getException(),
+                ]);
+
                 $event->setResponse(new JsonResponse(
                     [
                         'code' => Response::HTTP_SERVICE_UNAVAILABLE,
@@ -81,6 +95,12 @@ class JwtKeyMisconfigurationSubscriber implements EventSubscriberInterface
         // other layers, so walk the exception chain.
         for ($e = $throwable; null !== $e; $e = $e->getPrevious()) {
             if ($e instanceof JWTEncodeFailureException || $e instanceof InvalidKeyProvided || $e instanceof CannotSignPayload) {
+                $this->authLogger->critical('JWT keys are unusable, answering 503 on token signing', [
+                    'event' => 'auth.jwt_key_unusable',
+                    'operation' => 'sign',
+                    'exception' => $throwable,
+                ]);
+
                 $event->setThrowable(new ServiceUnavailableHttpException(
                     self::RETRY_AFTER_SECONDS,
                     'Service temporarily unavailable. Please try again later.',

--- a/src/EventSubscriber/JwtKeyMisconfigurationSubscriber.php
+++ b/src/EventSubscriber/JwtKeyMisconfigurationSubscriber.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Lcobucci\JWT\Signer\CannotSignPayload;
+use Lcobucci\JWT\Signer\InvalidKeyProvided;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Surfaces unusable JWT signing keys as "503 Service Unavailable" instead of
+ * a false "401 Invalid JWT Token" (validation) or a generic 500 (issuing).
+ *
+ * When the configured JWT key pair cannot be loaded (e.g. key files lost in
+ * a deployment, yielding an OpenSSL "DECODER routines::unsupported" parse
+ * failure), every token validation fails. That is a server-side
+ * misconfiguration, not a problem with the client's token — answering 401
+ * makes clients (e.g. the screen client) discard perfectly good tokens and
+ * log out. A 503 with a Retry-After header tells them the outage is
+ * temporary: retry later, do not re-authenticate.
+ *
+ * Two interception points are needed:
+ *
+ * - Token validation: Lexik builds the 401 response inside its authenticator
+ *   without throwing to the kernel, so the 401 → 503 swap must happen on
+ *   Lexik's JWT_INVALID event.
+ * - Token issuing (login, refresh): signing failures escape as uncaught
+ *   JWTEncodeFailureException, handled on kernel.exception.
+ */
+class JwtKeyMisconfigurationSubscriber implements EventSubscriberInterface
+{
+    final public const int RETRY_AFTER_SECONDS = 10;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::JWT_INVALID => 'onJwtInvalid',
+            // Positive priority so this runs before the framework's
+            // exception listeners render a response from the original
+            // throwable.
+            KernelEvents::EXCEPTION => ['onKernelException', 50],
+        ];
+    }
+
+    public function onJwtInvalid(JWTInvalidEvent $event): void
+    {
+        // A token rejected because of the token itself (bad signature,
+        // malformed, expired) must stay a 401. Only a key that cannot be
+        // loaded at all marks the service as unable to validate any token.
+        for ($e = $event->getException(); null !== $e; $e = $e->getPrevious()) {
+            if ($e instanceof InvalidKeyProvided || $e instanceof CannotSignPayload) {
+                $event->setResponse(new JsonResponse(
+                    [
+                        'code' => Response::HTTP_SERVICE_UNAVAILABLE,
+                        'message' => 'Service temporarily unavailable. Please try again later.',
+                    ],
+                    Response::HTTP_SERVICE_UNAVAILABLE,
+                    ['Retry-After' => self::RETRY_AFTER_SECONDS],
+                ));
+
+                return;
+            }
+        }
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $throwable = $event->getThrowable();
+
+        // Failing to *sign* a token is always a key/configuration problem on
+        // the server, never a client error. The failure may be wrapped by
+        // other layers, so walk the exception chain.
+        for ($e = $throwable; null !== $e; $e = $e->getPrevious()) {
+            if ($e instanceof JWTEncodeFailureException || $e instanceof InvalidKeyProvided || $e instanceof CannotSignPayload) {
+                $event->setThrowable(new ServiceUnavailableHttpException(
+                    self::RETRY_AFTER_SECONDS,
+                    'Service temporarily unavailable. Please try again later.',
+                    $throwable,
+                ));
+
+                return;
+            }
+        }
+    }
+}

--- a/tests/Api/DatabaseUnavailableTest.php
+++ b/tests/Api/DatabaseUnavailableTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\User;
+use App\Enum\UserTypeEnum;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifies that an unreachable database surfaces as "503 Service Unavailable"
+ * and never as a false "401 Unauthorized".
+ *
+ * A 401 makes API clients (e.g. the screen client) discard their tokens and
+ * log out, so a database outage must not bubble up through the JWT
+ * authenticator as an authentication failure.
+ */
+class DatabaseUnavailableTest extends ApiTestCase
+{
+    // Port 1 on localhost is never listening, so the connection attempt
+    // fails immediately with "connection refused".
+    private const UNREACHABLE_DATABASE_URL = 'mysql://root:password@127.0.0.1:1/db_test?serverVersion=11.4.4-MariaDB';
+
+    private ?string $originalEnvDatabaseUrl = null;
+    private ?string $originalServerDatabaseUrl = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalEnvDatabaseUrl = $_ENV['DATABASE_URL'] ?? null;
+        $this->originalServerDatabaseUrl = $_SERVER['DATABASE_URL'] ?? null;
+
+        $_ENV['DATABASE_URL'] = self::UNREACHABLE_DATABASE_URL;
+        $_SERVER['DATABASE_URL'] = self::UNREACHABLE_DATABASE_URL;
+    }
+
+    protected function tearDown(): void
+    {
+        if (null === $this->originalEnvDatabaseUrl) {
+            unset($_ENV['DATABASE_URL']);
+        } else {
+            $_ENV['DATABASE_URL'] = $this->originalEnvDatabaseUrl;
+        }
+
+        if (null === $this->originalServerDatabaseUrl) {
+            unset($_SERVER['DATABASE_URL']);
+        } else {
+            $_SERVER['DATABASE_URL'] = $this->originalServerDatabaseUrl;
+        }
+
+        parent::tearDown();
+    }
+
+    public function testJwtAuthenticatedRequestReturns503NotFalse401WhenDatabaseIsUnreachable(): void
+    {
+        $client = self::createClient();
+
+        // Create a valid JWT without touching the database. The signing keys
+        // are file based, so this works even though the database is down.
+        $user = new User();
+        $user->setProviderId('test@example.com');
+        $user->setEmail('test@example.com');
+        $user->setFullName('Test Test');
+        $user->setUserType(UserTypeEnum::USERNAME_PASSWORD);
+
+        $token = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+
+        $response = $client->request('GET', '/v2/layouts', [
+            'auth_bearer' => $token,
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $statusCode = $response->getStatusCode();
+
+        $this->assertNotSame(
+            Response::HTTP_UNAUTHORIZED,
+            $statusCode,
+            'An unreachable database must not surface as a false 401 — that logs out otherwise authenticated clients.'
+        );
+        $this->assertSame(
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            $statusCode,
+            'An unreachable database should surface as 503 Service Unavailable.'
+        );
+        $this->assertResponseHasHeader('Retry-After', 'A 503 caused by a database outage should tell clients when to retry.');
+    }
+
+    public function testLoginRequestReturns503NotFalse401WhenDatabaseIsUnreachable(): void
+    {
+        $client = self::createClient();
+
+        $response = $client->request('POST', '/v2/authentication/token', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'json' => [
+                'providerId' => 'test@example.com',
+                'password' => 'password',
+            ],
+        ]);
+
+        $statusCode = $response->getStatusCode();
+
+        $this->assertNotSame(
+            Response::HTTP_UNAUTHORIZED,
+            $statusCode,
+            'An unreachable database must not surface as a false 401 "bad credentials" on login.'
+        );
+        $this->assertSame(
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            $statusCode,
+            'An unreachable database should surface as 503 Service Unavailable.'
+        );
+    }
+}

--- a/tests/Api/JwtKeyMisconfigurationTest.php
+++ b/tests/Api/JwtKeyMisconfigurationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use App\Entity\User;
+use App\Enum\UserTypeEnum;
+use App\Tests\AbstractBaseApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifies that unusable JWT signing keys (a server-side misconfiguration)
+ * surface as "503 Service Unavailable" and never as a false "401 Invalid JWT
+ * Token" that blames the client's token.
+ *
+ * Seen in production during the v2 → v3 upgrade: the JWT key files were not
+ * migrated, so the key loader handed lcobucci/jwt the key *path* as if it
+ * were the key itself. Parsing failed with OpenSSL "error:1E08010C:DECODER
+ * routines::unsupported", every token validation answered 401, and token
+ * issuing/refresh answered 500 — making the screen client discard a
+ * perfectly good token and log out.
+ */
+class JwtKeyMisconfigurationTest extends AbstractBaseApiTestCase
+{
+    // Key paths configured for the test env in
+    // config/packages/test/lexik_jwt_authentication.yaml.
+    private const array KEY_FILES = [
+        'tests/config/jwt/private-test.pem',
+        'tests/config/jwt/public-test.pem',
+    ];
+
+    /** @var string[] */
+    private array $movedKeyFiles = [];
+
+    protected function tearDown(): void
+    {
+        $this->restoreKeyFiles();
+
+        parent::tearDown();
+    }
+
+    public function testJwtAuthenticatedRequestReturns503NotFalse401WhenJwtKeysAreMissing(): void
+    {
+        // Mint a perfectly valid JWT while the keys are still in place.
+        self::createClient();
+
+        $user = new User();
+        $user->setProviderId('test@example.com');
+        $user->setEmail('test@example.com');
+        $user->setFullName('Test Test');
+        $user->setUserType(UserTypeEnum::USERNAME_PASSWORD);
+
+        $token = $this->getJwtToken($user);
+
+        $this->removeKeyFiles();
+
+        $client = self::createClient();
+        $response = $client->request('GET', '/v2/layouts', [
+            'auth_bearer' => $token,
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $statusCode = $response->getStatusCode();
+
+        $this->assertNotSame(
+            Response::HTTP_UNAUTHORIZED,
+            $statusCode,
+            'Missing/unusable JWT keys are a server-side misconfiguration and must not surface as a false 401 — that logs out clients whose tokens are fine.'
+        );
+        $this->assertSame(
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            $statusCode,
+            'Missing/unusable JWT keys should surface as 503 Service Unavailable.'
+        );
+        $this->assertResponseHasHeader('Retry-After', 'A 503 caused by unusable JWT keys should tell clients when to retry.');
+    }
+
+    public function testLoginWithValidCredentialsReturns503WhenJwtKeysAreMissing(): void
+    {
+        $this->removeKeyFiles();
+
+        // Valid fixture credentials: authentication succeeds against the
+        // database, then signing the JWT fails because the keys are gone.
+        $client = self::createClient();
+        $response = $client->request('POST', '/v2/authentication/token', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'json' => [
+                'providerId' => 'admin@example.com',
+                'password' => 'apassword',
+            ],
+        ]);
+
+        $this->assertSame(
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            $response->getStatusCode(),
+            'Failing to sign a JWT because of missing/unusable keys should surface as 503 Service Unavailable, not a generic 500.'
+        );
+        $this->assertResponseHasHeader('Retry-After', 'A 503 caused by unusable JWT keys should tell clients when to retry.');
+    }
+
+    private function removeKeyFiles(): void
+    {
+        // Boot a fresh kernel afterwards so nothing has the keys cached.
+        self::ensureKernelShutdown();
+
+        $projectDir = \dirname(__DIR__, 2);
+
+        foreach (self::KEY_FILES as $keyFile) {
+            $path = $projectDir.'/'.$keyFile;
+            self::assertFileExists($path);
+            self::assertTrue(rename($path, $path.'.moved-away'), sprintf('Could not move key file "%s" out of the way.', $path));
+            $this->movedKeyFiles[] = $path;
+        }
+    }
+
+    private function restoreKeyFiles(): void
+    {
+        foreach ($this->movedKeyFiles as $path) {
+            if (file_exists($path.'.moved-away')) {
+                rename($path.'.moved-away', $path);
+            }
+        }
+
+        $this->movedKeyFiles = [];
+    }
+}

--- a/tests/EventSubscriber/DatabaseUnavailableExceptionSubscriberTest.php
+++ b/tests/EventSubscriber/DatabaseUnavailableExceptionSubscriberTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventSubscriber;
+
+use App\EventSubscriber\DatabaseUnavailableExceptionSubscriber;
+use Doctrine\DBAL\Driver\PDO\Exception as PdoDriverException;
+use Doctrine\DBAL\Exception\ConnectionException;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class DatabaseUnavailableExceptionSubscriberTest extends TestCase
+{
+    private TestHandler $handler;
+    private DatabaseUnavailableExceptionSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->handler = new TestHandler();
+        $this->subscriber = new DatabaseUnavailableExceptionSubscriber(new Logger('database', [$this->handler]));
+    }
+
+    public function testWrappedConnectionExceptionBecomes503AndLogsError(): void
+    {
+        $connectionException = new ConnectionException(
+            PdoDriverException::new(new \PDOException('SQLSTATE[HY000] [2002] Connection refused')),
+            null,
+        );
+        // Wrapped by another layer, as it may be when it escapes a service.
+        $exception = new \RuntimeException('wrapped', 0, $connectionException);
+        $event = $this->createExceptionEvent($exception);
+
+        $this->subscriber->onKernelException($event);
+
+        $throwable = $event->getThrowable();
+        $this->assertInstanceOf(ServiceUnavailableHttpException::class, $throwable);
+        $this->assertSame($exception, $throwable->getPrevious());
+        $this->assertTrue($throwable->getHeaders()['Retry-After'] > 0);
+
+        $this->assertTrue($this->handler->hasRecordThatMatches('/database is unavailable/', Level::Error));
+        $record = $this->handler->getRecords()[0];
+        $this->assertSame('db.unavailable', $record->context['event']);
+        $this->assertSame($exception, $record->context['exception']);
+    }
+
+    public function testUnrelatedExceptionIsLeftAloneAndLogsNothing(): void
+    {
+        $exception = new \RuntimeException('something else');
+        $event = $this->createExceptionEvent($exception);
+
+        $this->subscriber->onKernelException($event);
+
+        $this->assertSame($exception, $event->getThrowable());
+        $this->assertSame([], $this->handler->getRecords());
+    }
+
+    private function createExceptionEvent(\Throwable $throwable): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create('/v2/layouts', Request::METHOD_GET),
+            HttpKernelInterface::MAIN_REQUEST,
+            $throwable,
+        );
+    }
+}

--- a/tests/EventSubscriber/JwtKeyMisconfigurationSubscriberTest.php
+++ b/tests/EventSubscriber/JwtKeyMisconfigurationSubscriberTest.php
@@ -46,7 +46,7 @@ class JwtKeyMisconfigurationSubscriberTest extends TestCase
         $this->subscriber->onJwtInvalid($event);
 
         $response = $event->getResponse();
-        $this->assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $response->getStatusCode(), (string) $response->getContent());
         $this->assertTrue($response->headers->has('Retry-After'));
 
         $this->assertTrue($this->handler->hasRecordThatMatches('/JWT keys are unusable/', Level::Critical));

--- a/tests/EventSubscriber/JwtKeyMisconfigurationSubscriberTest.php
+++ b/tests/EventSubscriber/JwtKeyMisconfigurationSubscriberTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventSubscriber;
+
+use App\EventSubscriber\JwtKeyMisconfigurationSubscriber;
+use Lcobucci\JWT\Signer\InvalidKeyProvided;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\InvalidTokenException;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class JwtKeyMisconfigurationSubscriberTest extends TestCase
+{
+    private TestHandler $handler;
+    private JwtKeyMisconfigurationSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->handler = new TestHandler();
+        $this->subscriber = new JwtKeyMisconfigurationSubscriber(new Logger('auth', [$this->handler]));
+    }
+
+    public function testJwtInvalidCausedByUnusableKeyAnswers503AndLogsCritical(): void
+    {
+        // The chain produced when the key file cannot be parsed:
+        // InvalidTokenException ← JWTDecodeFailureException ← InvalidKeyProvided.
+        $exception = new InvalidTokenException('Invalid JWT Token', 0, new JWTDecodeFailureException(
+            JWTDecodeFailureException::INVALID_TOKEN,
+            'Invalid JWT Token',
+            InvalidKeyProvided::cannotBeParsed('error:1E08010C:DECODER routines::unsupported'),
+        ));
+        $event = new JWTInvalidEvent($exception, new JsonResponse(['code' => 401], Response::HTTP_UNAUTHORIZED));
+
+        $this->subscriber->onJwtInvalid($event);
+
+        $response = $event->getResponse();
+        $this->assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $response->getStatusCode());
+        $this->assertTrue($response->headers->has('Retry-After'));
+
+        $this->assertTrue($this->handler->hasRecordThatMatches('/JWT keys are unusable/', Level::Critical));
+        $record = $this->handler->getRecords()[0];
+        $this->assertSame('auth.jwt_key_unusable', $record->context['event']);
+        $this->assertSame('validate', $record->context['operation']);
+        $this->assertSame($exception, $record->context['exception']);
+    }
+
+    public function testJwtInvalidCausedByTheTokenItselfKeeps401AndLogsNothing(): void
+    {
+        $original = new JsonResponse(['code' => 401], Response::HTTP_UNAUTHORIZED);
+        $event = new JWTInvalidEvent(
+            new InvalidTokenException('Invalid JWT Token', 0, new JWTDecodeFailureException(
+                JWTDecodeFailureException::INVALID_TOKEN,
+                'Invalid JWT Token',
+            )),
+            $original,
+        );
+
+        $this->subscriber->onJwtInvalid($event);
+
+        $this->assertSame($original, $event->getResponse());
+        $this->assertSame([], $this->handler->getRecords());
+    }
+
+    public function testEncodeFailureBecomes503AndLogsCritical(): void
+    {
+        $exception = new JWTEncodeFailureException(
+            JWTEncodeFailureException::UNSIGNED_TOKEN,
+            'Unable to create a signed JWT from the given configuration.',
+        );
+        $event = $this->createExceptionEvent($exception);
+
+        $this->subscriber->onKernelException($event);
+
+        $throwable = $event->getThrowable();
+        $this->assertInstanceOf(ServiceUnavailableHttpException::class, $throwable);
+        $this->assertSame($exception, $throwable->getPrevious());
+
+        $this->assertTrue($this->handler->hasRecordThatMatches('/JWT keys are unusable/', Level::Critical));
+        $record = $this->handler->getRecords()[0];
+        $this->assertSame('auth.jwt_key_unusable', $record->context['event']);
+        $this->assertSame('sign', $record->context['operation']);
+        $this->assertSame($exception, $record->context['exception']);
+    }
+
+    public function testUnrelatedExceptionIsLeftAloneAndLogsNothing(): void
+    {
+        $exception = new \RuntimeException('something else');
+        $event = $this->createExceptionEvent($exception);
+
+        $this->subscriber->onKernelException($event);
+
+        $this->assertSame($exception, $event->getThrowable());
+        $this->assertSame([], $this->handler->getRecords());
+    }
+
+    private function createExceptionEvent(\Throwable $throwable): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create('/v2/authentication/token', Request::METHOD_POST),
+            HttpKernelInterface::MAIN_REQUEST,
+            $throwable,
+        );
+    }
+}


### PR DESCRIPTION
## What

Hardens the API so server-side outages surface as an explicit **503 Service Unavailable** (with `Retry-After`) and verifiably never as a false **401** that makes clients discard their tokens and log out:

1. **Missing/unusable JWT signing keys** → 503 instead of a false `401 Invalid JWT Token` on token validation, and instead of a generic 500 on token issuing (login/refresh).
2. **Database connectivity failures** (Doctrine DBAL `ConnectionException`, on any endpoint including token refresh) → 503 instead of a generic 500.

Each reclassification is logged per ADR 011 (see below).

## Why — what actually happened during the v2 → v3 upgrade test

A screen was logged out with the 404 → 401 → 500 → 200 pattern. Staging logs pinned the root cause: **the JWT key files were not migrated** (`jwt/` contained only `.gitignore`):

```
Lcobucci\JWT\Signer\InvalidKeyProvided:
It was not possible to parse your key, reason:
* error:1E08010C:DECODER routines::unsupported
```

Lexik's `AbstractKeyLoader` hands lcobucci/jwt the configured key **path as if it were the key** when the file is missing, so OpenSSL fails to parse it. Every token validation then answers `401 Invalid JWT Token` — blaming the client's token for a server-side misconfiguration — and token issuing/refresh answers a generic 500 (`JWTEncodeFailureException`). The screen client cannot tell "service misconfigured/down, retry later" from "credentials rejected", so it wiped its tokens, logged out and dropped into re-bind (ER101).

The Lexik 401 is built inside the authenticator (never reaching `kernel.exception`), which is why this needs interception on Lexik's `JWT_INVALID` event rather than a kernel listener alone.

## How

- `App\EventSubscriber\JwtKeyMisconfigurationSubscriber`
  - `JWT_INVALID` event: if the exception chain contains `InvalidKeyProvided`/`CannotSignPayload`, replace the 401 response with a 503 + `Retry-After`. Genuine token problems (expired, malformed, bad signature) still answer 401.
  - `kernel.exception`: map `JWTEncodeFailureException` (signing failures on login/refresh) to `ServiceUnavailableHttpException` (503 + `Retry-After`).
- `App\EventSubscriber\DatabaseUnavailableExceptionSubscriber`
  - `kernel.exception`: walk the exception chain and map DBAL `ConnectionException` (covers connect failure, `ConnectionLost`, refused credentials) to 503 + `Retry-After`.

## Logging (ADR 011 / docs/logging.md)

| Event | Channel | Level | When |
|---|---|---|---|
| `auth.jwt_key_unusable` | `auth` | `critical` | JWT keys can't be loaded; 503 answered on validation (`operation: validate`) or signing (`operation: sign`). Critical: the auth subsystem is down for every client. |
| `db.unavailable` | `database` | `error` | A request was answered 503 because of a DBAL `ConnectionException`. The underlying connect failure is still logged at `critical` by `ConnectionErrorMiddleware`. |

Static messages, exception under the `exception` context key, explicit channel-logger bindings in `services.yaml`. Documented in a new "503 Service Unavailable hardening" section in `docs/logging.md`. The `logging.*` PHPStan rules pass.

## TDD

Red-phase findings, then fixes:

- `tests/Api/JwtKeyMisconfigurationTest` — mints a valid JWT, then **moves the configured key files away** (reproducing the production failure mode exactly, path-as-key and all) and asserts: GET with a valid token is **503, not 401**; login with valid fixture credentials is **503, not 500**. Key files are restored in `tearDown`. Verified red without the subscriber (401/500), green with it.
- `tests/Api/DatabaseUnavailableTest` — boots the kernel with `DATABASE_URL` pointing at an unreachable host and asserts JWT-authenticated requests and login answer **503, not 401** (red phase showed a plain DB outage surfaces as 500, never 401 — the false 401 came from the key misconfiguration above).
- `tests/EventSubscriber/*SubscriberTest` — unit tests (Monolog `TestHandler`) for the log records and the negative cases: token-caused 401s stay 401 and log nothing; unrelated exceptions are untouched.

Full API suite green: 229 tests, 858 assertions. PHPStan, php-cs-fixer and markdownlint clean.

No `/v2/` contract change — 5xx classification is not part of the published API surface, so the oasdiff gate is unaffected.

## Notes for the upgrade

- The immediate operational fix for the staging environment is to migrate/regenerate the JWT key pair (`jwt/` was empty). Worth adding to `UPGRADE.md`'s v3 checklist.
- Follow-up (out of scope): the screen client could additionally keep its tokens on any 5xx from the refresh endpoint, now that the API guarantees outages are 503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)