### PR TITLE
fix(client): restore the 2.x screen auto-upgrade path via /client/release.json

### DIFF
--- a/.github/workflows/github_build_release.yml
+++ b/.github/workflows/github_build_release.yml
@@ -76,12 +76,19 @@ jobs:
             launch.json
 
       - name: Write release.json
+        # The copy at public/client/release.json is DEPRECATED: it exists only
+        # to provide an upgrade path for still-running 2.x screen clients,
+        # which poll /client/release.json. Without it the Symfony catch-all
+        # /client{subroutes} route answers with the SPA's index.html and 2.x
+        # screens never detect the new release. Remove once 2.x clients are
+        # out of the field.
         run: |
           printf '{"releaseTimestamp": %s, "releaseTime": "%s", "releaseVersion": "%s"}\n' \
             "$(date +%s)" \
             "$(date -u)" \
             "${{ github.ref_name }}" \
             > public/release.json
+          cp public/release.json public/client/release.json
           cat public/release.json
 
       - name: Make assets dir

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@
 # Ignore the public/fixtures folder.
 /public/fixtures
 
-# Ignore release json file.
+# Ignore release json file (and its deprecated copy for the 2.x client upgrade path).
 /public/release.json
+/public/client/release.json
 
 ###> symfony/framework-bundle ###
 /.env.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed the 2.x → 3.0 screen client auto-upgrade path: ship a copy of `release.json` at the
+  deprecated `/client/release.json` location polled by 2.x clients. Without it the catch-all
+  `/client` route answered with the SPA's HTML and already-running 2.x screens never detected
+  the new release (manual reload of every screen was required). The copy is deprecated and
+  will be removed once 2.x clients are out of the field. See `UPGRADE.md`.
+
 ## [3.0.0-rc5] - 2026-06-10
 
 - Added structured, channel-split application logging (ADR 011): per-domain Monolog channels with

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -289,3 +289,24 @@ docker compose exec phpfpm bin/console app:feed:remove-deprecated-feed-sources -
 ```
 
 Event database feeds should be recreated using `EventDatabaseApiV2FeedType`.
+
+#### 9 - Screen client auto-upgrade
+
+Running 2.x screen clients poll `/client/release.json` to detect new releases and reload
+themselves. In 3.0 the release file lives at `/release.json` (site root); the old path is
+a catch-all route serving the client SPA, so without further action 2.x screens would
+never detect the upgrade and would need a manual reload.
+
+The 3.0 images and release tarball therefore ship a copy at `public/client/release.json`.
+**This location is deprecated** and will be removed once 2.x clients are out of the field.
+With those deploys, running 2.x screens reload into the 3.0 client on their next release
+check (every 10 minutes by default) — no operator action required.
+
+If you deploy from source instead, nothing generates the release file — your deploy
+process must write it (shape per `docs/release-example.json`):
+
+```shell
+printf '{"releaseTimestamp": %s, "releaseTime": "%s", "releaseVersion": "%s"}\n' \
+  "$(date +%s)" "$(date -u)" "<version>" > public/release.json
+cp public/release.json public/client/release.json
+```

--- a/infrastructure/display-api-service/Dockerfile
+++ b/infrastructure/display-api-service/Dockerfile
@@ -77,11 +77,18 @@ RUN APP_ENV=prod composer install --no-dev --optimize-autoloader --classmap-auth
 
 # The client polls /release.json to detect when a screen should refresh;
 # shape per docs/release-example.json.
+#
+# DEPRECATED: the copy at /client/release.json exists only to provide an
+# upgrade path for still-running 2.x screen clients, which poll that path.
+# Without it the Symfony catch-all /client{subroutes} route answers with the
+# SPA's index.html and 2.x screens never detect the new release. Remove once
+# 2.x clients are out of the field.
 RUN printf '{"releaseTimestamp": %s, "releaseTime": "%s", "releaseVersion": "%s"}\n' \
       "${APP_RELEASE_TIMESTAMP}" \
       "${APP_RELEASE_TIME}" \
       "${APP_VERSION}" \
-      > public/release.json
+      > public/release.json \
+    && cp public/release.json public/client/release.json
 
 
 ################################


### PR DESCRIPTION
## Summary

2.x screen clients poll `/client/release.json` to detect new releases and reload themselves. In 3.0 the release file moved to `/release.json` (site root), and the catch-all `/client{subroutes}` route answers the old path with the SPA's index.html. The 2.x client's `response.json()` then fails silently, so already-running 2.x screens never detect the 3.0 release — every screen would need a manual reload after the server upgrade.

This PR ships a copy of `release.json` at the deprecated `public/client/release.json` location so v2 screens self-upgrade into the 3.0 client on their next release check (every 10 minutes by default). Static files win over the Symfony catch-all in the nginx image, so the copy is served as JSON. The location is deprecated and exists only to provide the upgrade path; remove once 2.x clients are out of the field.

## Files Changed

* `infrastructure/display-api-service/Dockerfile` - also write `public/client/release.json` in the production image build (the nginx image inherits it via `COPY --from=app`)
* `.github/workflows/github_build_release.yml` - same copy in the release tarball
* `UPGRADE.md` - new step 9: auto-upgrade works out of the box for image/tarball deploys; source deploys must generate both files in their deploy process (snippet included)
* `CHANGELOG.md` - entry under `[Unreleased]`
* `.gitignore` - ignore the new copy alongside `/public/release.json`

## Test Plan

Verified live on os2display-clone.itkdev.dk (v2 develop → 3.0.0-rc5 upgrade test):

1. Before: `GET /client/release.json` returned `200 text/html` (SPA index); a v2 screen reattached to the API but stayed on the old client indefinitely.
2. Manually placed the copy in the nginx container: `GET /client/release.json` returns `200 application/json` with the rc5 timestamp.
3. The stranded v2 screen detected the new `releaseTimestamp` on its next 10-minute check and reloaded into the 3.0.0-rc5 client without manual intervention.

To verify the build changes: build the production image and check `public/client/release.json` exists in both the app and nginx images with the same content as `public/release.json`; for the tarball, check the next release archive contains both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)