### PR TITLE
fix(api): silence api-platform legacy parameter-validator deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Disabled API Platform's legacy query-parameter validation system
+  (`legacy_query_parameter_validation: false`): its classes self-deprecate on load since 3.4,
+  spamming the `php` log channel on every request, and none of our filters declare the
+  constraints it enforces. The component is removed in API Platform 4.
+
 ## [3.0.0-rc6] - 2026-06-10
 
 - Fixed the 2.x → 3.0 screen client auto-upgrade path: images and the release tarball now also

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -39,6 +39,14 @@ api_platform:
     doctrine:
         enabled: true
 
+    validator:
+        # Don't register API Platform's legacy query-parameter validation
+        # system (ApiPlatform\ParameterValidator\...): its validator classes
+        # self-deprecate on load since 3.4, and none of our filters declare
+        # the constraints it enforces (all are required => false, no
+        # enum/bounds/length). The component is removed in API Platform 4.
+        legacy_query_parameter_validation: false
+
     swagger:
         versions: [3]
     #        api_keys:
@@ -57,7 +65,6 @@ api_platform:
         # The 4 following handlers are registered by default, keep those lines to prevent unexpected side effects
         Symfony\Component\Serializer\Exception\ExceptionInterface: 400 # Use a raw status code (recommended)
         ApiPlatform\Exception\InvalidArgumentException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST
-        ApiPlatform\ParameterValidator\Exception\ValidationExceptionInterface: 400
         Doctrine\ORM\OptimisticLockException: 409
 
         # Validation exception


### PR DESCRIPTION
## Summary

API Platform 3.4 registers its **legacy query-parameter validation system** by default (`legacy_query_parameter_validation` defaults to `true`), and the validator classes it instantiates (`ApiPlatform\ParameterValidator\Validator\Bounds` et al.) call `trigger_deprecation()` when loaded — so every request, including plain 404s from scanner probes, logs a deprecation to the `php` channel in production.

This PR disables the legacy system with one config line. **No behavior change**: the legacy validator only enforces constraints filters declare in `getDescription()` (`required`, enum, bounds, length), and all four project filters (`SharedWithMe`, `PublishedFilter`, `MultipleSearchFilter`, `CampaignFilter`) declare `required => false` and none of those constraint keys — it currently enforces nothing. The modern replacement (`Metadata\Parameter::$constraints`) is not used in this codebase either. The component is removed entirely in API Platform 4, so this is also a small step toward that upgrade.

## Files Changed

* `config/packages/api_platform.yaml` - set `validator.legacy_query_parameter_validation: false`; drop the now-dead `ApiPlatform\ParameterValidator\Exception\ValidationExceptionInterface: 400` entry from `exception_to_status` (nothing can throw it anymore)
* `CHANGELOG.md` - entry under `[Unreleased]`

## Test Plan

Verified locally:

1. `cache:clear`, then requests to `/v2/layouts` (API route) and `/js/twint_ch.js` (the 404 probe path from the original report) — neither logs the `Bounds` deprecation anymore; the last occurrence in `var/log/dev.log` predates the change.
2. `task generate:api-spec` — the exported OpenAPI spec is byte-identical (the legacy validator plays no part in spec generation), so the apispec CI gate sees no drift.
3. CI PHPUnit suite covers the filter endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)