### PR TITLE
feat: add app:utils:convert-env-to-3x command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#495](https://github.com/os2display/display-api-service/pull/495)
+  - Added `app:utils:convert-env-to-3x` command that converts the loaded configuration of a running 2.x
+    installation (env vars + admin/client config.json) to 3.x environment configuration, with screen,
+    dotenv and docker compose output formats.
 - [#444](https://github.com/os2display/display-api-service/pull/444)
   - Renamed 15 `changed_idx` indexes to `<table>_changed_idx` for cross-platform portability
     (Postgres scopes index names schema-wide).

--- a/README.md
+++ b/README.md
@@ -308,6 +308,41 @@ variable](https://symfony.com/doc/current/components/phpunit_bridge.html#configu
 docker compose exec --env SYMFONY_DEPRECATIONS_HELPER=disabled phpfpm composer tests
 ```
 
+## Preparing an upgrade to 3.x
+
+The `app:utils:convert-env-to-3x` command converts the configuration of this
+(2.x) installation to 3.x environment configuration. The values _loaded_ in
+the running application are treated as canonical — whether they come from
+real environment variables, a docker compose `environment` block or
+`.env`/`.env.local` files — and every variable the application reads is
+written out under its 3.x name.
+
+Unless `--skip-config-json` is given, the command also fetches the canonical
+admin and client configuration from `<app-url>/admin/config.json` and
+`<app-url>/client/config.json` and converts them to the 3.x `ADMIN_*` and
+`CLIENT_*` variables. The base URL is inferred from the loaded OIDC redirect
+URIs (or `COMPOSE_DOMAIN`) and can be overridden with `--app-url`.
+
+```shell
+# Review on screen (default):
+docker compose exec phpfpm bin/console app:utils:convert-env-to-3x
+
+# Write a dotenv file, the starting point for the 3.x .env.local:
+docker compose exec phpfpm bin/console app:utils:convert-env-to-3x \
+  --output=env --file=env.3x --app-url=https://display.example.com
+
+# Or a docker compose environment block:
+docker compose exec phpfpm bin/console app:utils:convert-env-to-3x --output=compose
+```
+
+Loaded variables the Symfony application cannot read (`COMPOSE_*`, `PHP_*`,
+`NGINX_*`, `MARIADB_*`/`MYSQL_*`) are listed in a trailing advisory with a
+note on where each belongs in a 3.x deployment: compose orchestration values
+go in the docker host `.env`, and the container-tuning values go on the
+respective containers (`.env.php`, `.env.nginx`, `.env.mariadb` in the
+`os2display-docker-server` file layout). They are never part of the
+application env output.
+
 ## CI
 
 Github Actions are used to run the test suite and code style checks on all PRs.

--- a/README.md
+++ b/README.md
@@ -327,13 +327,20 @@ URIs (or `COMPOSE_DOMAIN`) and can be overridden with `--app-url`.
 # Review on screen (default):
 docker compose exec phpfpm bin/console app:utils:convert-env-to-3x
 
-# Write a dotenv file, the starting point for the 3.x .env.local:
-docker compose exec phpfpm bin/console app:utils:convert-env-to-3x \
-  --output=env --file=env.3x --app-url=https://display.example.com
+# Write a dotenv file ON THE HOST, the starting point for the 3.x .env.local.
+# With --output=env (and --output=compose) the document goes to stdout and all
+# notes/warnings go to stderr, so the result can be redirected from outside
+# the container (-T: no TTY, keeps stdout byte-clean):
+docker compose exec -T phpfpm bin/console app:utils:convert-env-to-3x \
+  --output=env --app-url=https://display.example.com > env.3x
 
 # Or a docker compose environment block:
-docker compose exec phpfpm bin/console app:utils:convert-env-to-3x --output=compose
+docker compose exec -T phpfpm bin/console app:utils:convert-env-to-3x --output=compose > env.3x.yml
 ```
+
+Note that `--file` writes inside the container, so it only makes sense for
+paths on a mounted volume; prefer the host-side redirect above in dockerised
+setups.
 
 Loaded variables the Symfony application cannot read (`COMPOSE_*`, `PHP_*`,
 `NGINX_*`, `MARIADB_*`/`MYSQL_*`) are listed in a trailing advisory with a

--- a/src/Command/Utils/ConvertEnvTo3xCommand.php
+++ b/src/Command/Utils/ConvertEnvTo3xCommand.php
@@ -1,0 +1,583 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\Utils;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[AsCommand(
+    name: 'app:utils:convert-env-to-3x',
+    description: 'Converts the loaded 2.x configuration (env + admin/client config.json) to 3.x environment configuration',
+)]
+class ConvertEnvTo3xCommand extends Command
+{
+    public const string OUTPUT_SCREEN = 'screen';
+    public const string OUTPUT_ENV = 'env';
+    public const string OUTPUT_COMPOSE = 'compose';
+
+    /**
+     * Maps every environment variable read by the 2.x application (as loaded
+     * in the running app, cf. .env) to its 3.x name. Most names are
+     * unchanged; the renames follow the 3.x UPGRADE.md rename table.
+     */
+    public const array ENV_MAP = [
+        // symfony/framework-bundle
+        'APP_ENV' => 'APP_ENV',
+        'APP_DEBUG' => 'APP_DEBUG',
+        'APP_SECRET' => 'APP_SECRET',
+        'TRUSTED_PROXIES' => 'TRUSTED_PROXIES',
+        // doctrine/doctrine-bundle
+        'DATABASE_URL' => 'DATABASE_URL',
+        // nelmio/cors-bundle
+        'CORS_ALLOW_ORIGIN' => 'CORS_ALLOW_ORIGIN',
+        // App
+        'APP_DEFAULT_DATE_FORMAT' => 'DEFAULT_DATE_FORMAT',
+        'APP_ACTIVATION_CODE_EXPIRE_INTERNAL' => 'ACTIVATION_CODE_EXPIRE_INTERVAL',
+        'APP_KEY_VAULT_SOURCE' => 'KEY_VAULT_SOURCE',
+        'APP_KEY_VAULT_JSON' => 'KEY_VAULT_JSON',
+        // lexik/jwt-authentication-bundle
+        'JWT_SECRET_KEY' => 'JWT_SECRET_KEY',
+        'JWT_PUBLIC_KEY' => 'JWT_PUBLIC_KEY',
+        'JWT_PASSPHRASE' => 'JWT_PASSPHRASE',
+        'JWT_TOKEN_TTL' => 'JWT_TOKEN_TTL',
+        'JWT_SCREEN_TOKEN_TTL' => 'JWT_SCREEN_TOKEN_TTL',
+        // gesdinet/jwt-refresh-token-bundle
+        'JWT_REFRESH_TOKEN_TTL' => 'JWT_REFRESH_TOKEN_TTL',
+        'JWT_SCREEN_REFRESH_TOKEN_TTL' => 'JWT_SCREEN_REFRESH_TOKEN_TTL',
+        // itk-dev/openid-connect-bundle, internal provider
+        'INTERNAL_OIDC_METADATA_URL' => 'INTERNAL_OIDC_METADATA_URL',
+        'INTERNAL_OIDC_CLIENT_ID' => 'INTERNAL_OIDC_CLIENT_ID',
+        'INTERNAL_OIDC_CLIENT_SECRET' => 'INTERNAL_OIDC_CLIENT_SECRET',
+        'INTERNAL_OIDC_REDIRECT_URI' => 'INTERNAL_OIDC_REDIRECT_URI',
+        'INTERNAL_OIDC_LEEWAY' => 'INTERNAL_OIDC_LEEWAY',
+        'INTERNAL_OIDC_CLAIM_NAME' => 'INTERNAL_OIDC_CLAIM_NAME',
+        'INTERNAL_OIDC_CLAIM_EMAIL' => 'INTERNAL_OIDC_CLAIM_EMAIL',
+        'INTERNAL_OIDC_CLAIM_GROUPS' => 'INTERNAL_OIDC_CLAIM_GROUPS',
+        // itk-dev/openid-connect-bundle, external provider
+        'EXTERNAL_OIDC_METADATA_URL' => 'EXTERNAL_OIDC_METADATA_URL',
+        'EXTERNAL_OIDC_CLIENT_ID' => 'EXTERNAL_OIDC_CLIENT_ID',
+        'EXTERNAL_OIDC_CLIENT_SECRET' => 'EXTERNAL_OIDC_CLIENT_SECRET',
+        'EXTERNAL_OIDC_REDIRECT_URI' => 'EXTERNAL_OIDC_REDIRECT_URI',
+        'EXTERNAL_OIDC_LEEWAY' => 'EXTERNAL_OIDC_LEEWAY',
+        'EXTERNAL_OIDC_HASH_SALT' => 'EXTERNAL_OIDC_HASH_SALT',
+        'EXTERNAL_OIDC_CLAIM_ID' => 'EXTERNAL_OIDC_CLAIM_ID',
+        'OIDC_CLI_REDIRECT' => 'OIDC_CLI_REDIRECT',
+        // redis
+        'REDIS_CACHE_PREFIX' => 'REDIS_CACHE_PREFIX',
+        'REDIS_CACHE_DSN' => 'REDIS_CACHE_DSN',
+        // Calendar Api Feed Source
+        'CALENDAR_API_FEED_SOURCE_LOCATION_ENDPOINT' => 'CALENDAR_API_FEED_SOURCE_LOCATION_ENDPOINT',
+        'CALENDAR_API_FEED_SOURCE_RESOURCE_ENDPOINT' => 'CALENDAR_API_FEED_SOURCE_RESOURCE_ENDPOINT',
+        'CALENDAR_API_FEED_SOURCE_EVENT_ENDPOINT' => 'CALENDAR_API_FEED_SOURCE_EVENT_ENDPOINT',
+        'CALENDAR_API_FEED_SOURCE_CUSTOM_MAPPINGS' => 'CALENDAR_API_FEED_SOURCE_CUSTOM_MAPPINGS',
+        'CALENDAR_API_FEED_SOURCE_EVENT_MODIFIERS' => 'CALENDAR_API_FEED_SOURCE_EVENT_MODIFIERS',
+        'CALENDAR_API_FEED_SOURCE_DATE_FORMAT' => 'CALENDAR_API_FEED_SOURCE_DATE_FORMAT',
+        'CALENDAR_API_FEED_SOURCE_DATE_TIMEZONE' => 'CALENDAR_API_FEED_SOURCE_DATE_TIMEZONE',
+        'CALENDAR_API_FEED_SOURCE_CACHE_EXPIRE_SECONDS' => 'CALENDAR_API_FEED_SOURCE_CACHE_EXPIRE_SECONDS',
+        'EVENTDATABASE_API_V2_CACHE_EXPIRE_SECONDS' => 'EVENTDATABASE_API_V2_CACHE_EXPIRE_SECONDS',
+        // Http Client
+        'HTTP_CLIENT_TIMEOUT' => 'HTTP_CLIENT_TIMEOUT',
+        'HTTP_CLIENT_MAX_DURATION' => 'HTTP_CLIENT_MAX_DURATION',
+        'HTTP_CLIENT_LOG_LEVEL' => 'LOG_LEVEL_OUTBOUND_HTTP',
+        // Screen info tracking
+        'TRACK_SCREEN_INFO' => 'TRACK_SCREEN_INFO',
+        'TRACK_SCREEN_INFO_UPDATE_INTERVAL_SECONDS' => 'TRACK_SCREEN_INFO_UPDATE_INTERVAL_SECONDS',
+    ];
+
+    /**
+     * Variables present in the 2.x .env that are docker compose
+     * orchestration config, not application config. They are deliberately
+     * not part of ENV_MAP and are reported through the infrastructure
+     * advisory instead.
+     */
+    public const array NON_APP_ENV = [
+        'COMPOSE_PROJECT_NAME',
+        'COMPOSE_DOMAIN',
+    ];
+
+    /**
+     * Environment prefixes the Symfony application cannot read. Where each
+     * belongs in a 3.x deployment (os2display-docker-server file layout).
+     */
+    private const array INFRA_PREFIXES = [
+        'COMPOSE_' => 'compose orchestration — belongs in the docker host .env, never in the application env',
+        'PHP_' => 'php-fpm container config — set on the phpfpm container (.env.php in os2display-docker-server)',
+        'NGINX_' => 'nginx container config — set on the nginx container (.env.nginx in os2display-docker-server)',
+        'MARIADB_' => 'database container config — set on the mariadb container (.env.mariadb in os2display-docker-server)',
+        'MYSQL_' => 'database container config — set on the mariadb container (.env.mariadb in os2display-docker-server)',
+    ];
+
+    /**
+     * PHP_*-named values that are CGI artefacts or php docker image build
+     * constants — never operator configuration, so excluded from the
+     * infrastructure advisory.
+     */
+    private const array INFRA_NOISE = [
+        'PHP_SELF',
+        'PHP_AUTH_USER',
+        'PHP_AUTH_PW',
+        'PHP_AUTH_DIGEST',
+        'PHP_VERSION',
+        'PHP_INI_DIR',
+        'PHP_CFLAGS',
+        'PHP_CPPFLAGS',
+        'PHP_LDFLAGS',
+        'PHP_SHA256',
+        'PHP_URL',
+        'PHP_ASC_URL',
+        'PHP_EXTRA_CONFIGURE_ARGS',
+        'PHP_EXTRA_BUILD_DEPS',
+        'PHPIZE_DEPS',
+    ];
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output format (screen, env or compose)', self::OUTPUT_SCREEN)
+            ->addOption('file', 'f', InputOption::VALUE_REQUIRED, 'Write the result to this file instead of stdout (env and compose output only)')
+            ->addOption('app-url', 'u', InputOption::VALUE_REQUIRED, 'Base URL of the 2.x installation, e.g. https://display.example.com. Inferred from the loaded environment when omitted.')
+            ->addOption('skip-config-json', null, InputOption::VALUE_NONE, 'Do not fetch admin/config.json and client/config.json')
+            ->setHelp(<<<'HELP'
+            Converts the configuration of a running 2.x installation to 3.x environment
+            configuration. The values <info>loaded</info> in the running application — whether they
+            come from real environment variables, a docker compose environment block or
+            .env/.env.local files — are treated as canonical, and every variable the 2.x
+            application reads is written out under its 3.x name.
+
+            Unless <comment>--skip-config-json</comment> is given, the command also fetches the canonical
+            admin and client configuration from <comment><app-url>/admin/config.json</comment> and
+            <comment><app-url>/client/config.json</comment> and converts them to the 3.x ADMIN_* and
+            CLIENT_* variables. The base URL is inferred from the loaded OIDC redirect
+            URIs (or COMPOSE_DOMAIN) and can be overridden with <comment>--app-url</comment>.
+            HELP);
+    }
+
+    final protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        // Keep stdout clean when the document itself goes there, so the
+        // result can be piped or redirected; notes and warnings go to stderr.
+        $errIo = $io->getErrorStyle();
+
+        $format = $input->getOption('output');
+        if (!in_array($format, [self::OUTPUT_SCREEN, self::OUTPUT_ENV, self::OUTPUT_COMPOSE], true)) {
+            $errIo->error(sprintf('Invalid output format "%s". Valid formats: %s.', $format, implode(', ', [self::OUTPUT_SCREEN, self::OUTPUT_ENV, self::OUTPUT_COMPOSE])));
+
+            return Command::INVALID;
+        }
+
+        $file = $input->getOption('file');
+        if (null !== $file && self::OUTPUT_SCREEN === $format) {
+            $errIo->error('--file requires --output=env or --output=compose.');
+
+            return Command::INVALID;
+        }
+
+        $sections = [
+            [
+                'title' => 'Converted from the loaded 2.x environment',
+                'lines' => $this->convertLoadedEnv(),
+            ],
+        ];
+
+        if (!$input->getOption('skip-config-json')) {
+            $appUrl = $input->getOption('app-url');
+            $baseUrl = is_string($appUrl) && '' !== $appUrl ? rtrim($appUrl, '/') : $this->inferAppUrl();
+
+            if (null === $baseUrl) {
+                $errIo->warning('Could not infer the 2.x app URL from the loaded environment. Pass --app-url=https://... to include the admin/client config.json conversion, or --skip-config-json to silence this warning.');
+            } else {
+                foreach (['admin', 'client'] as $type) {
+                    $url = sprintf('%s/%s/config.json', $baseUrl, $type);
+                    $config = $this->fetchConfig($url, $errIo);
+                    if (null !== $config) {
+                        $sections[] = [
+                            'title' => sprintf('%s configuration (from %s)', ucfirst($type), $url),
+                            'lines' => 'admin' === $type ? $this->convertAdminConfig($config) : $this->convertClientConfig($config),
+                        ];
+                    }
+                }
+            }
+        }
+
+        $infra = $this->collectInfraEnv();
+        $document = self::OUTPUT_COMPOSE === $format
+            ? $this->renderCompose($sections, $infra)
+            : $this->renderEnv($sections, $infra);
+
+        if (null !== $file) {
+            if (false === file_put_contents($file, $document)) {
+                $errIo->error(sprintf('Could not write to "%s".', $file));
+
+                return Command::FAILURE;
+            }
+            $errIo->success(sprintf('Wrote %s configuration to %s. Review the result before use.', $format, $file));
+
+            return Command::SUCCESS;
+        }
+
+        if (self::OUTPUT_SCREEN === $format) {
+            $io->title('2.x configuration converted to 3.x environment configuration');
+            $io->writeln($document);
+            $io->note('Review the result, then save it with --output=env --file=<path> (or --output=compose) and use it as the starting point for the 3.x .env.local.');
+
+            return Command::SUCCESS;
+        }
+
+        $output->writeln($document);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Converts every loaded 2.x application variable to its 3.x name.
+     *
+     * @return list<array{string, string}>
+     */
+    private function convertLoadedEnv(): array
+    {
+        $lines = [];
+
+        foreach (self::ENV_MAP as $name2x => $name3x) {
+            $value = $this->lookupEnv($name2x);
+            if (null !== $value) {
+                $lines[] = [$name3x, $value];
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Looks up a loaded value the way Symfony's env processor does:
+     * $_ENV first, then $_SERVER, then the process environment.
+     */
+    private function lookupEnv(string $name): ?string
+    {
+        $value = $_ENV[$name] ?? $_SERVER[$name] ?? getenv($name);
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Infers the public base URL of the 2.x installation from the loaded
+     * environment. The OIDC redirect URIs point at the public domain on
+     * a configured installation; COMPOSE_DOMAIN covers itk-dev
+     * development setups.
+     */
+    private function inferAppUrl(): ?string
+    {
+        foreach (['INTERNAL_OIDC_REDIRECT_URI', 'EXTERNAL_OIDC_REDIRECT_URI', 'OIDC_CLI_REDIRECT'] as $name) {
+            $value = $this->lookupEnv($name);
+            if (null === $value) {
+                continue;
+            }
+
+            $parts = parse_url($value);
+            if (!is_array($parts)) {
+                continue;
+            }
+
+            $scheme = $parts['scheme'] ?? '';
+            $host = $parts['host'] ?? '';
+            if (in_array($scheme, ['http', 'https'], true) && '' !== $host) {
+                $url = $scheme.'://'.$host;
+                if (isset($parts['port'])) {
+                    $url .= ':'.$parts['port'];
+                }
+
+                return $url;
+            }
+        }
+
+        $domain = $this->lookupEnv('COMPOSE_DOMAIN');
+        if (null !== $domain && '' !== $domain) {
+            return 'https://'.$domain;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fetchConfig(string $url, SymfonyStyle $errIo): ?array
+    {
+        try {
+            return $this->httpClient->request('GET', $url)->toArray();
+        } catch (\Throwable $throwable) {
+            $errIo->warning(sprintf('Could not fetch %s (%s). The corresponding section is omitted — pass --app-url to point at the public 2.x URL, or use app:utils:convert-config-json-to-env in 3.x with a config.json file.', $url, $throwable->getMessage()));
+
+            return null;
+        }
+    }
+
+    /**
+     * Converts a 2.x admin config.json to the 3.x ADMIN_* variables.
+     *
+     * The 2.x file is generated by confd, which renders booleans and null
+     * as the strings "true"/"false"/"null" — both the JSON and string
+     * representations are accepted here.
+     *
+     * @param array<string, mixed> $config
+     *
+     * @return list<array{string, string}>
+     */
+    private function convertAdminConfig(array $config): array
+    {
+        $lines = [];
+
+        $rejseplanenApiKey = $config['rejseplanenApiKey'] ?? null;
+        if (!$this->isNullish($rejseplanenApiKey) && is_scalar($rejseplanenApiKey)) {
+            $lines[] = ['ADMIN_REJSEPLANEN_APIKEY', (string) $rejseplanenApiKey];
+        }
+
+        $showScreenStatus = $this->toBool($config['showScreenStatus'] ?? null);
+        if (null !== $showScreenStatus) {
+            $lines[] = ['ADMIN_SHOW_SCREEN_STATUS', $showScreenStatus ? 'true' : 'false'];
+        }
+
+        $touchButtonRegions = $this->toBool($config['touchButtonRegions'] ?? null);
+        if (null !== $touchButtonRegions) {
+            $lines[] = ['ADMIN_TOUCH_BUTTON_REGIONS', $touchButtonRegions ? 'true' : 'false'];
+        }
+
+        $loginMethods = $config['loginMethods'] ?? null;
+        if (is_array($loginMethods)) {
+            $converted = [];
+            foreach ($loginMethods as $method) {
+                if (!is_array($method)) {
+                    continue;
+                }
+                // In 2.x a method with enabled=false is hidden; in 3.x
+                // presence in ADMIN_LOGIN_METHODS means enabled, so disabled
+                // methods are dropped and the obsolete key stripped.
+                if (array_key_exists('enabled', $method) && false === $this->toBool($method['enabled'])) {
+                    continue;
+                }
+                unset($method['enabled']);
+                $converted[] = $method;
+            }
+            $lines[] = ['ADMIN_LOGIN_METHODS', json_encode($converted, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)];
+        }
+
+        // 2.x configured a preview client URL; in 3.x this is a boolean
+        // toggle for the built-in preview.
+        if (!$this->isNullish($config['previewClient'] ?? null)) {
+            $lines[] = ['ADMIN_ENHANCED_PREVIEW', 'true'];
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Converts a 2.x client config.json to the 3.x CLIENT_* variables.
+     *
+     * @param array<string, mixed> $config
+     *
+     * @return list<array{string, string}>
+     */
+    private function convertClientConfig(array $config): array
+    {
+        $lines = [];
+
+        $scalars = [
+            'loginCheckTimeout' => 'CLIENT_LOGIN_CHECK_TIMEOUT',
+            'refreshTokenTimeout' => 'CLIENT_REFRESH_TOKEN_TIMEOUT',
+            'releaseTimestampIntervalTimeout' => 'CLIENT_RELEASE_TIMESTAMP_INTERVAL_TIMEOUT',
+            'schedulingInterval' => 'CLIENT_SCHEDULING_INTERVAL',
+        ];
+        foreach ($scalars as $key => $name3x) {
+            $value = $config[$key] ?? null;
+            if (!$this->isNullish($value) && is_scalar($value)) {
+                $lines[] = [$name3x, (string) $value];
+            }
+        }
+
+        $dataStrategy = $config['dataStrategy'] ?? null;
+        $dataStrategyConfig = is_array($dataStrategy) ? ($dataStrategy['config'] ?? null) : null;
+        $pullInterval = is_array($dataStrategyConfig) ? ($dataStrategyConfig['interval'] ?? null) : null;
+        if (!$this->isNullish($pullInterval) && is_scalar($pullInterval)) {
+            $lines[] = ['CLIENT_PULL_STRATEGY_INTERVAL', (string) $pullInterval];
+        }
+
+        $colorScheme = $config['colorScheme'] ?? null;
+        if (is_array($colorScheme)) {
+            $lines[] = ['CLIENT_COLOR_SCHEME', json_encode($colorScheme, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)];
+        }
+
+        $debug = $this->toBool($config['debug'] ?? null);
+        if (null !== $debug) {
+            $lines[] = ['CLIENT_DEBUG', $debug ? 'true' : 'false'];
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Collects loaded variables the Symfony application cannot read
+     * (container/orchestration config), keyed by name, with the advice on
+     * where they belong in a 3.x deployment.
+     *
+     * @return array<string, array{string, string}> name => [value, advice]
+     */
+    private function collectInfraEnv(): array
+    {
+        $found = [];
+
+        // Real process env (compose environment blocks land here) merged
+        // with the dotenv-loaded vars in $_ENV.
+        $candidates = array_merge(getenv(), $_ENV);
+
+        /** @var mixed $value */
+        foreach ($candidates as $name => $value) {
+            if (!is_string($value) || in_array($name, self::INFRA_NOISE, true)) {
+                continue;
+            }
+            foreach (self::INFRA_PREFIXES as $prefix => $advice) {
+                if (str_starts_with($name, $prefix)) {
+                    $found[$name] = [$value, $advice];
+                    break;
+                }
+            }
+        }
+
+        ksort($found);
+
+        return $found;
+    }
+
+    /**
+     * @param list<array{title: string, lines: list<array{string, string}>}> $sections
+     * @param array<string, array{string, string}> $infra
+     */
+    private function renderEnv(array $sections, array $infra): string
+    {
+        $out = [];
+
+        foreach ($sections as $section) {
+            $out[] = sprintf('###> %s ###', $section['title']);
+            foreach ($section['lines'] as [$name, $value]) {
+                $out[] = $name.'='.$this->quoteEnvValue($value);
+            }
+            $out[] = sprintf('###< %s ###', $section['title']);
+            $out[] = '';
+        }
+
+        foreach ($this->renderInfraAdvisory($infra) as $line) {
+            $out[] = '' === $line ? '' : '# '.$line;
+        }
+
+        return rtrim(implode(PHP_EOL, $out)).PHP_EOL;
+    }
+
+    /**
+     * @param list<array{title: string, lines: list<array{string, string}>}> $sections
+     * @param array<string, array{string, string}> $infra
+     */
+    private function renderCompose(array $sections, array $infra): string
+    {
+        $out = [];
+        $out[] = '# Merge into the api service in your compose file.';
+        $out[] = 'environment:';
+
+        foreach ($sections as $section) {
+            $out[] = '  # '.$section['title'];
+            foreach ($section['lines'] as [$name, $value]) {
+                // YAML single-quoted scalar; embedded single quotes are
+                // escaped by doubling.
+                $out[] = sprintf("  - '%s=%s'", $name, str_replace("'", "''", $value));
+            }
+        }
+
+        $out[] = '';
+        foreach ($this->renderInfraAdvisory($infra) as $line) {
+            $out[] = '' === $line ? '' : '# '.$line;
+        }
+
+        return rtrim(implode(PHP_EOL, $out)).PHP_EOL;
+    }
+
+    /**
+     * @param array<string, array{string, string}> $infra
+     *
+     * @return list<string>
+     */
+    private function renderInfraAdvisory(array $infra): array
+    {
+        if ([] === $infra) {
+            return [];
+        }
+
+        $lines = [
+            'The following loaded variables are NOT read by the Symfony application',
+            'and must not go in the application env. They configure the container',
+            'stack — put them where noted:',
+        ];
+
+        $grouped = [];
+        foreach ($infra as $name => [$value, $advice]) {
+            $grouped[$advice][] = sprintf('%s=%s', $name, $value);
+        }
+
+        foreach ($grouped as $advice => $vars) {
+            $lines[] = '';
+            $lines[] = $advice.':';
+            foreach ($vars as $var) {
+                $lines[] = '    '.$var;
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Quotes a value for use in a dotenv file when needed.
+     */
+    private function quoteEnvValue(string $value): string
+    {
+        if (1 === preg_match('#^[A-Za-z0-9_./:%@+,=~^?&-]*$#', $value)) {
+            return $value;
+        }
+
+        if (!str_contains($value, "'")) {
+            return "'".$value."'";
+        }
+
+        return '"'.str_replace(['\\', '"', '$'], ['\\\\', '\\"', '\\$'], $value).'"';
+    }
+
+    private function isNullish(mixed $value): bool
+    {
+        return null === $value || '' === $value || 'null' === $value;
+    }
+
+    /**
+     * Interprets JSON and confd-rendered ("true"/"false") booleans.
+     */
+    private function toBool(mixed $value): ?bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        }
+
+        return null;
+    }
+}

--- a/src/Command/Utils/ConvertEnvTo3xCommand.php
+++ b/src/Command/Utils/ConvertEnvTo3xCommand.php
@@ -237,7 +237,9 @@ class ConvertEnvTo3xCommand extends Command
             return Command::SUCCESS;
         }
 
-        $output->writeln($document);
+        // write(), not writeln(): the document is newline-terminated, and
+        // byte-exact stdout matters when redirecting to a file on the host.
+        $output->write($document);
 
         return Command::SUCCESS;
     }

--- a/src/Command/Utils/ConvertEnvTo3xCommand.php
+++ b/src/Command/Utils/ConvertEnvTo3xCommand.php
@@ -231,6 +231,7 @@ class ConvertEnvTo3xCommand extends Command
 
         if (self::OUTPUT_SCREEN === $format) {
             $io->title('2.x configuration converted to 3.x environment configuration');
+            $errIo->warning('This output contains secrets (e.g. APP_SECRET, JWT_PASSPHRASE, OIDC client secrets, the database password). Treat it accordingly — do not paste it into logs, issues or chat.');
             $io->writeln($document);
             $io->note('Review the result, then save it with --output=env --file=<path> (or --output=compose) and use it as the starting point for the 3.x .env.local.');
 
@@ -319,7 +320,12 @@ class ConvertEnvTo3xCommand extends Command
     private function fetchConfig(string $url, SymfonyStyle $errIo): ?array
     {
         try {
-            return $this->httpClient->request('GET', $url)->toArray();
+            return $this->httpClient->request('GET', $url, [
+                // Cap the wait so an unreachable host fails predictably
+                // rather than hanging on the default connect/response timeout.
+                'timeout' => 10,
+                'max_duration' => 10,
+            ])->toArray();
         } catch (\Throwable $throwable) {
             $errIo->warning(sprintf('Could not fetch %s (%s). The corresponding section is omitted — pass --app-url to point at the public 2.x URL, or use app:utils:convert-config-json-to-env in 3.x with a config.json file.', $url, $throwable->getMessage()));
 

--- a/tests/Command/ConvertEnvTo3xCommandTest.php
+++ b/tests/Command/ConvertEnvTo3xCommandTest.php
@@ -36,7 +36,7 @@ class ConvertEnvTo3xCommandTest extends TestCase
         $dotEnv = file_get_contents(dirname(__DIR__, 2).'/.env');
         $this->assertNotFalse($dotEnv);
 
-        $this->assertSame(1, preg_match_all('/^([A-Z][A-Z0-9_]*)=/m', $dotEnv, $matches) >= 1 ? 1 : 0);
+        $this->assertGreaterThan(0, preg_match_all('/^([A-Z][A-Z0-9_]*)=/m', $dotEnv, $matches));
 
         $covered = array_merge(array_keys(ConvertEnvTo3xCommand::ENV_MAP), ConvertEnvTo3xCommand::NON_APP_ENV);
         foreach ($matches[1] as $name) {

--- a/tests/Command/ConvertEnvTo3xCommandTest.php
+++ b/tests/Command/ConvertEnvTo3xCommandTest.php
@@ -179,6 +179,32 @@ class ConvertEnvTo3xCommandTest extends TestCase
         $this->assertStringContainsString('Could not infer the 2.x app URL', $tester->getDisplay(true));
     }
 
+    public function testStdoutStaysCleanWhenFetchFails(): void
+    {
+        $this->setEnv('APP_ENV', 'prod');
+
+        // Every request fails — the warning must go to stderr so stdout can
+        // be redirected to a file on the host from outside the container.
+        $client = new MockHttpClient(fn () => new MockResponse('Service Unavailable', ['http_code' => 503]));
+
+        $tester = $this->createCommandTester($client);
+        $exitCode = $tester->execute(
+            ['--output' => 'env', '--app-url' => 'https://display.example.com'],
+            ['capture_stderr_separately' => true],
+        );
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Could not fetch', $tester->getErrorOutput());
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('APP_ENV=prod', $display);
+        $this->assertStringNotContainsString('Could not fetch', $display);
+        // Parseable as dotenv: nothing but KEY=value, comments and blanks.
+        foreach (explode("\n", rtrim($display)) as $line) {
+            $this->assertMatchesRegularExpression('/^$|^#|^[A-Z][A-Z0-9_]*=/', $line);
+        }
+    }
+
     public function testComposeOutput(): void
     {
         $this->setEnv('APP_ENV', 'prod');

--- a/tests/Command/ConvertEnvTo3xCommandTest.php
+++ b/tests/Command/ConvertEnvTo3xCommandTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\Utils\ConvertEnvTo3xCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ConvertEnvTo3xCommandTest extends TestCase
+{
+    /** @var array<string, string|false> */
+    private array $envBackup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $name => $original) {
+            if (false === $original) {
+                unset($_ENV[$name]);
+            } else {
+                $_ENV[$name] = $original;
+            }
+        }
+        $this->envBackup = [];
+
+        parent::tearDown();
+    }
+
+    public function testEveryEnvVarInDotEnvIsCovered(): void
+    {
+        $dotEnv = file_get_contents(dirname(__DIR__, 2).'/.env');
+        $this->assertNotFalse($dotEnv);
+
+        $this->assertSame(1, preg_match_all('/^([A-Z][A-Z0-9_]*)=/m', $dotEnv, $matches) >= 1 ? 1 : 0);
+
+        $covered = array_merge(array_keys(ConvertEnvTo3xCommand::ENV_MAP), ConvertEnvTo3xCommand::NON_APP_ENV);
+        foreach ($matches[1] as $name) {
+            $this->assertContains($name, $covered, sprintf('Env var "%s" from .env is not covered by %s::ENV_MAP — add it with its 3.x name (or to NON_APP_ENV if it is not application config).', $name, ConvertEnvTo3xCommand::class));
+        }
+    }
+
+    public function testRenamesLoadedEnvVarsTo3xNames(): void
+    {
+        $this->setEnv('APP_ENV', 'prod');
+        $this->setEnv('APP_DEFAULT_DATE_FORMAT', 'Y-m-d');
+        $this->setEnv('APP_ACTIVATION_CODE_EXPIRE_INTERNAL', 'P2D');
+        $this->setEnv('APP_KEY_VAULT_SOURCE', 'ENVIRONMENT');
+        $this->setEnv('APP_KEY_VAULT_JSON', '{}');
+        $this->setEnv('HTTP_CLIENT_LOG_LEVEL', 'error');
+        $this->setEnv('DATABASE_URL', 'mysql://db:db@mariadb:3306/db?serverVersion=10.11.5-MariaDB');
+
+        $tester = $this->createCommandTester(new MockHttpClient());
+        $exitCode = $tester->execute(['--output' => 'env', '--skip-config-json' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('APP_ENV=prod', $display);
+        $this->assertStringContainsString('DEFAULT_DATE_FORMAT=Y-m-d', $display);
+        $this->assertStringContainsString('ACTIVATION_CODE_EXPIRE_INTERVAL=P2D', $display);
+        $this->assertStringContainsString('KEY_VAULT_SOURCE=ENVIRONMENT', $display);
+        $this->assertStringContainsString('KEY_VAULT_JSON=', $display);
+        $this->assertStringContainsString('LOG_LEVEL_OUTBOUND_HTTP=error', $display);
+        $this->assertStringContainsString('DATABASE_URL=mysql://db:db@mariadb:3306/db?serverVersion=10.11.5-MariaDB', $display);
+
+        $this->assertStringNotContainsString('APP_DEFAULT_DATE_FORMAT=', $display);
+        $this->assertStringNotContainsString('APP_ACTIVATION_CODE_EXPIRE_INTERNAL=', $display);
+        $this->assertStringNotContainsString('HTTP_CLIENT_LOG_LEVEL=', $display);
+    }
+
+    public function testConvertsAdminAndClientConfigJson(): void
+    {
+        $requestedUrls = [];
+        $client = new MockHttpClient(function (string $method, string $url) use (&$requestedUrls): MockResponse {
+            $requestedUrls[] = $url;
+
+            // The bodies mirror what confd renders in 2.x: booleans and
+            // null as strings.
+            if (str_contains($url, '/admin/config.json')) {
+                return new MockResponse((string) json_encode([
+                    'api' => '/',
+                    'touchButtonRegions' => 'true',
+                    'previewClient' => 'https://preview.example.com',
+                    'showScreenStatus' => 'false',
+                    'rejseplanenApiKey' => 'null',
+                    'loginMethods' => [
+                        ['type' => 'oidc', 'enabled' => 'true', 'provider' => 'internal', 'label' => null, 'icon' => 'faCity'],
+                        ['type' => 'oidc', 'enabled' => 'false', 'provider' => 'external', 'label' => '', 'icon' => 'mitID'],
+                        ['type' => 'username-password', 'enabled' => 'true', 'provider' => 'username-password', 'label' => null],
+                    ],
+                ]), ['response_headers' => ['content-type' => 'application/json']]);
+            }
+
+            return new MockResponse((string) json_encode([
+                'apiEndpoint' => '/',
+                'loginCheckTimeout' => 20000,
+                'configFetchInterval' => 600000,
+                'refreshTokenTimeout' => 60000,
+                'releaseTimestampIntervalTimeout' => 600000,
+                'dataStrategy' => ['type' => 'pull', 'config' => ['interval' => 30000]],
+                'colorScheme' => ['type' => 'library', 'lat' => 56.0, 'lng' => 10.0],
+                'schedulingInterval' => 60000,
+                'debug' => false,
+            ]), ['response_headers' => ['content-type' => 'application/json']]);
+        });
+
+        $tester = $this->createCommandTester($client);
+        $exitCode = $tester->execute(['--output' => 'env', '--app-url' => 'https://display.example.com']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertSame([
+            'https://display.example.com/admin/config.json',
+            'https://display.example.com/client/config.json',
+        ], $requestedUrls);
+
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('ADMIN_TOUCH_BUTTON_REGIONS=true', $display);
+        $this->assertStringContainsString('ADMIN_SHOW_SCREEN_STATUS=false', $display);
+        $this->assertStringContainsString('ADMIN_ENHANCED_PREVIEW=true', $display);
+        // "null" means not configured.
+        $this->assertStringNotContainsString('ADMIN_REJSEPLANEN_APIKEY', $display);
+        // The disabled external method is dropped, and the obsolete
+        // "enabled" key stripped from the remaining methods.
+        $this->assertStringContainsString('ADMIN_LOGIN_METHODS=', $display);
+        $this->assertStringNotContainsString('"provider":"external"', $display);
+        $this->assertStringNotContainsString('"enabled"', $display);
+        $this->assertStringContainsString('"provider":"internal"', $display);
+        $this->assertStringContainsString('"provider":"username-password"', $display);
+
+        $this->assertStringContainsString('CLIENT_LOGIN_CHECK_TIMEOUT=20000', $display);
+        $this->assertStringContainsString('CLIENT_REFRESH_TOKEN_TIMEOUT=60000', $display);
+        $this->assertStringContainsString('CLIENT_RELEASE_TIMESTAMP_INTERVAL_TIMEOUT=600000', $display);
+        $this->assertStringContainsString('CLIENT_SCHEDULING_INTERVAL=60000', $display);
+        $this->assertStringContainsString('CLIENT_PULL_STRATEGY_INTERVAL=30000', $display);
+        $this->assertStringContainsString('"type":"library"', $display);
+        $this->assertStringContainsString('CLIENT_DEBUG=false', $display);
+    }
+
+    public function testInfersAppUrlFromOidcRedirectUri(): void
+    {
+        $this->setEnv('INTERNAL_OIDC_REDIRECT_URI', 'https://display.example.com/admin/redirect');
+
+        $requestedUrls = [];
+        $client = new MockHttpClient(function (string $method, string $url) use (&$requestedUrls): MockResponse {
+            $requestedUrls[] = $url;
+
+            return new MockResponse('{}', ['response_headers' => ['content-type' => 'application/json']]);
+        });
+
+        $tester = $this->createCommandTester($client);
+        $exitCode = $tester->execute(['--output' => 'env']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertSame([
+            'https://display.example.com/admin/config.json',
+            'https://display.example.com/client/config.json',
+        ], $requestedUrls);
+    }
+
+    public function testWarnsWhenAppUrlCannotBeInferred(): void
+    {
+        // Placeholder values (the committed .env defaults) must not be
+        // mistaken for a URL.
+        $this->setEnv('INTERNAL_OIDC_REDIRECT_URI', 'INTERNAL_OIDC_REDIRECT_URI');
+        $this->setEnv('EXTERNAL_OIDC_REDIRECT_URI', 'EXTERNAL_OIDC_REDIRECT_URI');
+        $this->setEnv('OIDC_CLI_REDIRECT', 'APP_CLI_REDIRECT_URI');
+        $this->setEnv('COMPOSE_DOMAIN', '');
+
+        $tester = $this->createCommandTester(new MockHttpClient());
+        $exitCode = $tester->execute(['--output' => 'env']);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Could not infer the 2.x app URL', $tester->getDisplay(true));
+    }
+
+    public function testComposeOutput(): void
+    {
+        $this->setEnv('APP_ENV', 'prod');
+
+        $tester = $this->createCommandTester(new MockHttpClient());
+        $exitCode = $tester->execute(['--output' => 'compose', '--skip-config-json' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('environment:', $display);
+        $this->assertStringContainsString("  - 'APP_ENV=prod'", $display);
+    }
+
+    public function testWritesToFile(): void
+    {
+        $this->setEnv('APP_ENV', 'prod');
+
+        $file = tempnam(sys_get_temp_dir(), 'env3x');
+        $this->assertNotFalse($file);
+
+        try {
+            $tester = $this->createCommandTester(new MockHttpClient());
+            $exitCode = $tester->execute(['--output' => 'env', '--file' => $file, '--skip-config-json' => true]);
+
+            $this->assertSame(Command::SUCCESS, $exitCode);
+
+            $written = file_get_contents($file);
+            $this->assertNotFalse($written);
+            $this->assertStringContainsString('APP_ENV=prod', $written);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testRejectsInvalidOutputFormat(): void
+    {
+        $tester = $this->createCommandTester(new MockHttpClient());
+
+        $this->assertSame(Command::INVALID, $tester->execute(['--output' => 'json']));
+    }
+
+    public function testRejectsFileWithScreenOutput(): void
+    {
+        $tester = $this->createCommandTester(new MockHttpClient());
+
+        $this->assertSame(Command::INVALID, $tester->execute(['--file' => '/tmp/foo']));
+    }
+
+    private function createCommandTester(HttpClientInterface $httpClient): CommandTester
+    {
+        return new CommandTester(new ConvertEnvTo3xCommand($httpClient));
+    }
+
+    private function setEnv(string $name, string $value): void
+    {
+        if (!array_key_exists($name, $this->envBackup)) {
+            $original = array_key_exists($name, $_ENV) && is_string($_ENV[$name]) ? $_ENV[$name] : false;
+            $this->envBackup[$name] = $original;
+        }
+
+        $_ENV[$name] = $value;
+    }
+}


### PR DESCRIPTION
## Summary
Adds `app:utils:convert-env-to-3x`, a command (similar in principle to 3.x's `app:utils:convert-config-json-to-env`) that converts the configuration of a running 2.x installation to 3.x environment configuration, to ease the 2.x → 3.x upgrade.

The values **loaded** in the running application are treated as canonical — whether they come from real environment variables, a docker compose `environment` block or `.env`/`.env.local` files — so the command works no matter how the installation injects its config.

## Features Added
* **Full env conversion**: every environment variable the 2.x app reads (everything in `.env`) is written out under its 3.x name, following the 3.x UPGRADE.md rename table (`APP_DEFAULT_DATE_FORMAT` → `DEFAULT_DATE_FORMAT`, `APP_ACTIVATION_CODE_EXPIRE_INTERNAL` → `ACTIVATION_CODE_EXPIRE_INTERVAL`, `APP_KEY_VAULT_*` → `KEY_VAULT_*`, `HTTP_CLIENT_LOG_LEVEL` → `LOG_LEVEL_OUTBOUND_HTTP`; `APP_ENV`/`APP_DEBUG`/`APP_SECRET` keep their Symfony-defined names).
* **Canonical config.json conversion**: infers the 2.x app URL from the loaded OIDC redirect URIs (or `COMPOSE_DOMAIN`; override with `--app-url`), fetches `<app-url>/admin/config.json` and `<app-url>/client/config.json` and converts them to the 3.x `ADMIN_*`/`CLIENT_*` variables. Handles the confd-rendered string booleans (`"true"`/`"false"`/`"null"`) the 2.x containers emit; disabled login methods are dropped since in 3.x presence in `ADMIN_LOGIN_METHODS` means enabled. `--skip-config-json` for offline use.
* **Three output formats** via `--output`: `screen` (default, annotated), `env` (dotenv document) and `compose` (compose `environment` block); `--file` writes the env/compose result to a file. Notes/warnings go to stderr so stdout stays pipeable.
* **Infrastructure advisory**: loaded variables the Symfony app cannot read (`COMPOSE_*`, `PHP_*`, `NGINX_*`, `MARIADB_*`/`MYSQL_*`) are listed in a trailing comment block with a note on where each belongs in a 3.x deployment (docker host `.env`, `.env.php`, `.env.nginx`, `.env.mariadb` in the os2display-docker-server layout) — they are never emitted as application env. PHP docker image build constants and CGI artefacts are filtered out.

## Files Changed
* `src/Command/Utils/ConvertEnvTo3xCommand.php` (new) — the command
* `tests/Command/ConvertEnvTo3xCommandTest.php` (new) — unit tests incl. a guard asserting every variable in `.env` stays covered by the 2.x→3.x map, so future env additions on develop can't silently fall out of the conversion
* `README.md` — "Preparing an upgrade to 3.x" section

## Test Plan
* `vendor/bin/phpunit tests/Command/ConvertEnvTo3xCommandTest.php` — 9 tests, green
* `bin/console app:utils:convert-env-to-3x --skip-config-json` in the dev stack — verified renames, quoting (regex/JSON values quoted, URLs bare) and the grouped advisory incl. real container `PHP_*` vars
* `--output=compose` verified; psalm, php-cs-fixer, rector and markdownlint all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)