### PR TITLE
Make dev cert creation run on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Made dev cert creation run on Linux.
+
 ## [3.0.0-rc7] - 2026-06-23
 
 - Made the application cache backend configurable via the new `CACHE_ADAPTER` env var (`redis`

--- a/scripts/dev-cert.sh
+++ b/scripts/dev-cert.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Generate a self-signed certificate for the bundled dev traefik.
 # Writes traefik/ssl/dev.{crt,key} covering COMPOSE_DOMAIN as the primary
@@ -13,7 +13,10 @@
 # Requires: docker. Uses alpine/openssl in a transient container so no
 # openssl is needed on the host.
 
-set -euo pipefail
+set -eu
+# `pipefail` is not supported by all `/bin/sh` implementations (e.g. dash).
+# Enable it when available so the script can still be run by `sh` from Task.
+(set -o pipefail) 2>/dev/null && set -o pipefail || true
 
 CERT_DIR="traefik/ssl"
 CERT_FILE="$CERT_DIR/dev.crt"

--- a/scripts/dev-cert.sh
+++ b/scripts/dev-cert.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Generate a self-signed certificate for the bundled dev traefik.
 # Writes traefik/ssl/dev.{crt,key} covering COMPOSE_DOMAIN as the primary
@@ -14,8 +14,6 @@
 # openssl is needed on the host.
 
 set -eu
-# `pipefail` is not supported by all `/bin/sh` implementations (e.g. dash).
-# Enable it when available so the script can still be run by `sh` from Task.
 (set -o pipefail) 2>/dev/null && set -o pipefail || true
 
 CERT_DIR="traefik/ssl"


### PR DESCRIPTION
#### Description
The script dev-cert.sh fails on Linux (ubuntu 22.04). Small change made to make it compatible. 

`pipefail` is not supported by all `/bin/sh` implementations (e.g. dash).
Enable it when available so the script can still be run by `sh` from Task.

Resolves #508

#### Screenshot of the result

Before: 
```
deploy@dev:~/display-api-service$ task dev:cert
task: [dev:cert] sh scripts/dev-cert.sh
scripts/dev-cert.sh: 16: set: Illegal option -o pipefail
task: Failed to run task "dev:cert": exit status 2
```

After:
```
deploy@dev:~/display-api-service$ task dev:cert
task: [dev:cert] sh scripts/dev-cert.sh
Unable to find image 'alpine/openssl:latest' locally
latest: Pulling from alpine/openssl
55afa1ecc21d: Already exists 
08efefb01827: Pull complete 
...
```

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

