### PR TITLE
Enable setting compose domain in .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,7 @@ services:
     working_dir: /app
     environment:
       - NODE_ENV=development
+      - COMPOSE_DOMAIN=${COMPOSE_DOMAIN}
     volumes:
       - .:/app:delegated
     labels:

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,8 @@ import react from "@vitejs/plugin-react-oxc";
 import svgr from "vite-plugin-svgr";
 
 export default defineConfig(() => {
+  const composeDomain = process.env.COMPOSE_DOMAIN || "display.local.itkdev.dk";
+
   return {
     base: "/build",
     css: {
@@ -42,7 +44,7 @@ export default defineConfig(() => {
     server: {
       host: "0.0.0.0",
       hmr: {
-        host: "node-display.local.itkdev.dk",
+        host: `node-${composeDomain}`,
         protocol: "wss",
         clientPort: 443
       },


### PR DESCRIPTION
- If I set COMPOSE_DOMAIN to a custom domain it is not passed to the node service.
- vite has display.local.itkdev.dk hardcoded



- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
